### PR TITLE
chore(docs): add template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/
+
+Typical format for test cases:
+```
+test(feature): general description of tests
+```
+
+Example:
+```
+test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
+```
+-->
+
+#### Summary
+<!--
+A description of this pull request.
+-->
+
+#### Is the feature in stable branch or under review?
+- [] Feature in stable branch (master, main)?
+- [] Feature still under review? If yes, list all related pull requests for reference.
+
+#### Test server
+<!--
+Link the test server to be used for testing and trying out the test cases could be from "/cloud", pull request or requirements to set up the test server.
+-->
+
+#### Test client
+<!--
+Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
+-->
+- [] Browser
+- [] Mobile App (version, OS)
+- [] Desktop App (version, OS)


### PR DESCRIPTION
#### Summary
This PR adds template for pull requests.




<a href="https://gitpod.io/#https://github.com/mattermost/mattermost-test-management/pull/6"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

