### PR TITLE
docs: edit readme + add info about deno tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,77 @@
 # Mattermost Test Management - Open Tests Initiative
 
-This project is created to increase the quality of Mattermost products by having highly effective, well-thought and well-maintained living test cases through high-collaboration and based on industry accepted best practices.
+This project was created to increase the quality of Mattermost products by having highly effective, well-thought and well-maintained living test cases through high collaboration and based on industry-accepted best practices.
 
 ## Contributing
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mattermost/mattermost-test-management)
 
-Still in active development from [QA Core Team](https://github.com/orgs/mattermost/teams/qa-core-team) and not yet ready for community contribution. However, feel free to file an issue if you find anything that needs our attention. We will update this section and will announce in our channels once we are all set to accept contributions. Keep on watching!
+As the [QA Core Team](https://github.com/orgs/mattermost/teams/qa-core-team) is still actively developing this project, it is not yet ready for community contribution. However, feel free to file an issue if you find anything that needs our attention. We will update this section and will announce it in our channels once we are all set to accept contributions. Keep on watching!
 
 ## Project status and Roadmap
-This project is actively maintained and owned by [QA Core Team](https://github.com/orgs/mattermost/teams/qa-core-team).
+This project is actively maintained and owned by the [QA Core Team](https://github.com/orgs/mattermost/teams/qa-core-team).
 
 Phases:
 1. Open test data and work with test organization.
-2. Open up test contribution from core staff using pull request flow and GitHub approval.
+2. Open up test contributions from core staff using pull request flow and GitHub approval.
 3. Open up test contributions to the community, especially from the QA Community.
 4. Build web applications for ease of viewing, creation, editing and reporting.
 5. Iterate and improve the Open Test Initiative.
 
-If you're interested in shaping this project, please reach out to our community channel at https://community.mattermost.com/core/channels/quality-assurance. Say hi and let us know what you think!
+If you're interested in shaping this project, please reach out to our [community channel](https://community.mattermost.com/core/channels/quality-assurance). Say hi, and let us know what you think!
 
 ## Folder Structure
-1. __`/data` folder__: Main folder of the repo where written test cases are primarily located. Test cases can be found at `/data/test-cases`.
+1. __`/data` folder__: Main folder of the repo where written test cases live primarily. Test cases can be found at `/data/test-cases`.
+    > *Note*: We're still in the process of restructuring the folder at `/data/test-cases`. The primary goal is to align with our Multi-Product Architecture. The rough structure would be `Product > Feature > Client > Test Cases`.
 
-> Note: We're still in the process of restructuring the folder at `/data/test-cases`. Primary goal is to align with our Multi-Product Architecture. Rough structure would be `Product > Feature > Client > Test Cases`.
-
-2. __`/src` folder__: Scripts that are used for integrating with our third-party Test Management System either for getting or syncing information.
+2. __`/src` folder__: Scripts used for integrating with our third-party Test Management System. These scripts retrieve or sync information.
 
 ## Getting started
 There are three ways to get started in contributing to this project.
-1. Highly recommended to [![open in Gitpod](https://img.shields.io/badge/open%20in-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/mattermost/mattermost-test-management) for it provides a fully initialized and readily available environment.
-2. With your local machine upon checking out this repo. You should have [Deno](https://deno.land/) installed in your machine so you could run scripts at the `/src` folder. See https://deno.land/#installation for installation.
-3. If you're contributing for test cases only where it's written in markdown file, you may do so directly via this GiHub repo. See GitHub docs on how to [create new files and submit pull request](https://docs.github.com/en/repositories/working-with-files/managing-files/creating-new-files).
+1. It is highly recommended to [![open in Gitpod](https://img.shields.io/badge/open%20in-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/mattermost/mattermost-test-management), for it provides a fully initialized and readily available environment.
+2. You can also work on your local machine by checking out this repo. Make sure you have [Deno](https://deno.land/) installed on your machine to run scripts in the /src folder. See the [Deno installation docs](https://deno.land/#installation) for more information.
+3. If you're contributing test cases only where they are written in Markdown files, you may do so directly via this GitHub repo. See the GitHub docs on [creating new files and submitting pull requests](https://docs.github.com/en/repositories/working-with-files/managing-files/creating-new-files).
 
-## Getting started if you're contributing to add or update test cases
-1. See test cases at `/data/test-cases`. Each test case is written in a markdown file in two main sections:\
-a. `Frontmatter` for metadata of a test case where each field is group into required, optional and do not change.\
-b. `Content` for description and steps information.
-2. When creating a test case:\
-a. Copy the basic template at [data/TEST_CASE_TEMPLATE.md](https://raw.githubusercontent.com/mattermost/mattermost-test-management/main/data/TEST_CASE_TEMPLATE.md).\
-b. Update the required information from the `Frontmatter` section such as:
-    - `name` - name of the test case
-    - `status` - with default value of `Approved`
-    - `priority` - with default value of `Normal`
-    - `folder` - name of a folder. It should follow the same name of existing folder (e.g. `Channels` for `data/test-cases/channels`) or a slug equivalent of new folder (e.g. `2236 Shiny Feature` for `data/test-cases/channels/2236-shiny-feature`). Note: `2236` is in the format of `YYWW` or a shortened year and week when a feature is introduced.
-    - `authors` - author's GitHub handle (e.g. `@original`)
-    - `team_ownership` - (array) Team name who owns a feature or test case.
-    - `priority_p1_to_p4` - with default value of `P2 - Core Functions (Do core functions work?)`
-c. Update the content section such as:
-    - `Objective` (optional)
-    - `Precondition` (optional)
-    - `Step` (array, required)
-      - description (required)
-      - `Test Data` (optional)
-      - `Expected` (optional)
-3. When updating a test case:\
-In addition to the same process when creating a new test case, the submitter should append his/her GitHub handle to `authors` field, comma-separated (e.g. `authors: @original,@updater`).
-4. Once change is final, run `deno task validate` and see if all changes are valid. Fix error as flagged in the terminal.
-5. Always run `deno task check` to ensure formatting is correct and no lint error. 
-6. Create a branch and submit changes as pull requests.
+### Getting started - adding or updating test cases
+1. View test cases at `/data/test-cases`. Each test case is written in a Markdown file with two main sections:
+    - `Frontmatter`: for the metadata of a test case where each field is grouped into the categories "required", "optional", and "do not change".
+    - `Content`: for the description and steps information.
+2. When creating a test case:
+    - Copy the basic template at [data/TEST_CASE_TEMPLATE.md](https://raw.githubusercontent.com/mattermost/mattermost-test-management/main/data/TEST_CASE_TEMPLATE.md).
+    - Update the required information in the `Frontmatter` section, such as:
+        - `name` - the name of the test case
+        - `status` - with the default value of `Approved`
+        - `priority` - with the default value of `Normal`
+        - `folder` - the name of a folder. It should follow the exact name of an existing folder (e.g. `Channels` for `data/test-cases/channels`) or a slug equivalent of a new folder (e.g. `2236 Shiny Feature` for `data/test-cases/channels/2236-shiny-feature`). 
+            > Note: `2236` is in the format of `YYWW` (shortened year and week) and refers to when a feature is introduced.
+        - `authors` - the author's GitHub handle (e.g. `@original`)
+        - `team_ownership` - (array) the team name; who owns a feature or test case.
+        - `priority_p1_to_p4` - has the default value of `P2 - Core Functions (Do core functions work?)`
+    - Update/populate the content section fields, such as:
+        - `Objective` (optional)
+        - `Precondition` (optional)
+        - `Step` (array, required)
+            - `Description` (required)
+            - `Test Data` (optional)
+            - `Expected` (optional)
+3. When updating a test case:
+    - In addition to the same process when creating a new test case, the submitter should append his/her GitHub handle to `authors` field, comma-separated (e.g. `authors: @original,@updater`).
+4. Once changes have been made, run `deno task validate` and see if all changes are valid. Fix errors that get flagged in the terminal.
+5. Always run `deno task check` to ensure all formatting is correct and there are no lint errors. 
+6. Create a branch and submit changes as a pull request(s).
+    > Note: It's highly recommended to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the `title` of the pull request.
 
-> Note: It's highly recommended to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the `title` of the pull request.
-
-## Getting started if you'd like to contribute with integration
-1. Checkout this repo and make sure that `Deno` is installed in your local machine or [![open in Gitpod](https://img.shields.io/badge/open%20in-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/mattermost/mattermost-test-management).
-2. Scripts can be found at `/src` folder and are all written in Typescript.
-3. Integrating Zephyr Scale and Jira requires its tokens. You may set via environment variables or via `.env` config with values for `ZEPHYR_TOKEN` and `JIRA_PAT`. See their docs on how to get tokens:
-- [Zephyr Scale API Access Token](https://support.smartbear.com/zephyr-scale-cloud/docs/rest-api/generating-api-access-tokens.html)
-- [Jira Personal Access Token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)
-4. See list of tasks that are available at [deno.jsonc]([here](https://github.com/mattermost/mattermost-test-management/blob/main/deno.jsonc)).
-5. Always run `deno task check` to ensure formatting is correct and no lint error.
-6. Create a branch and submit changes as pull requests.
-
-> Note: It's highly recommended to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the `title` of the pull request.
+### Getting started - working with integrations
+1. Checkout this repo and make sure that `Deno` is installed on your local machine or [![open in Gitpod](https://img.shields.io/badge/open%20in-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/mattermost/mattermost-test-management).
+2. Scripts can be found in the `/src` folder and are all written in Typescript.
+3. Integrating Zephyr Scale and Jira requires access tokens. You may set these via environment variables or through an `.env` config file with values for `ZEPHYR_TOKEN` and `JIRA_PAT`. See these docs on how to get the access tokens:
+    - [Zephyr Scale API Access Token](https://support.smartbear.com/zephyr-scale-cloud/docs/rest-api/generating-api-access-tokens.html)
+    - [Jira Personal Access Token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)
+4. See a list of tasks that are available at [deno.jsonc](https://github.com/mattermost/mattermost-test-management/blob/main/deno.jsonc). You can also list these tasks using the `deno task` command at the root of the repository.
+    - To start up Silver Bullet (SB), run `deno task silverbullet`, then navigate to http://localhost:3333.
+    - To start the test management site, navigate into the `www` folder (`cd www`), run `deno task start`, then navigate to http://localhost:8000/.
+5. Always run `deno task check` to ensure all formatting is correct and there are no lint errors.
+6. Create a branch and submit changes as a pull request(s).
+    > Note: It's highly recommended to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the `title` of the pull request.
 
 ## License
-Licensed under Apache License 2.0. Read full text [here](https://github.com/mattermost/mattermost-test-management/blob/main/LICENSE).
+Licensed under Apache License 2.0. Read the full text [here](https://github.com/mattermost/mattermost-test-management/blob/main/LICENSE).


### PR DESCRIPTION
#### Summary
Cleaned up some grammar and spelling mistakes in the readme, as well as added some text about specific deno tasks like `deno task silverbullet` and `deno task start`. 

#### Is the feature in a stable branch or under review?
N/A, just readme text changes.



<a href="https://gitpod.io/#https://github.com/mattermost/mattermost-test-management/pull/31"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

