### PR TITLE
fix: broken test page

### DIFF
--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -50,8 +50,17 @@ export const handler: Handlers<Data> = {
     if (!entry) {
       return ctx.renderNotFound();
     }
+
+    // Convert test key to uppercase to match naming convention of the actual markdown file
+    const filePath = entry.slug.split("/").map((part, index, arr) => {
+      if (index === arr.length - 1) {
+        return part.toUpperCase();
+      }
+      return part;
+    }).join("/");
+
     const url = new URL(
-      `../../../${testCasesFolderFullPath}/${entry.slug}.md`,
+      `../../../${testCasesFolderFullPath}/${filePath}.md`,
       import.meta.url,
     );
 


### PR DESCRIPTION
#### Summary
This fixes the issue https://github.com/mattermost/mattermost-test-management/issues/32 as reported by @simcard0000.

In Gitpod and Deno Deploy, the markdown file requires case-sensitive when accessing the file. Not really sure why it's has different behavior in local.

Can be verified by accessing the web application as deployed in Gitpod (ex. `https://8000-mattermost-mattermostte-5z2tnd7c7j3.ws-us78.gitpod.io/test-cases/apps-framework/figma/mm-t5157`) which should not show 500 error.



<a href="https://gitpod.io/#https://github.com/mattermost/mattermost-test-management/pull/34"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

