### PR TITLE
test(MM-T5361): Mobile V2: Invite - Should show no results item in search list

### DIFF
--- a/data/test-cases/mobile-v2/invite-people/MM-T5361.md
+++ b/data/test-cases/mobile-v2/invite-people/MM-T5361.md
@@ -42,7 +42,7 @@ steps_hashed: 97f3683db4eaeef5d5531fa7f3da9ca284e8881a87ee4d1267e4dd74c6ed9f072f
 
 - Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
 - Specifically for this test we need to ensure that no results will appear in the search list under certain conditions.
-- Note: For more information about this feature refer to the links in the Traceability tab above.
+- Note: For more information about this feature refer to the links in the Traceability tab for this test case in Zephyr Scale.
 
 **Precondition**
 

--- a/data/test-cases/mobile-v2/invite-people/MM-T5361.md
+++ b/data/test-cases/mobile-v2/invite-people/MM-T5361.md
@@ -40,24 +40,25 @@ steps_hashed: 97f3683db4eaeef5d5531fa7f3da9ca284e8881a87ee4d1267e4dd74c6ed9f072f
 
 **Objective**
 
-Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
-Specifically for this test we need to ensure that no results will appear in the search list under certain conditions.
-Note: For more information about this feature refer to the links in the Traceability tab above.
+- Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
+- Specifically for this test we need to ensure that no results will appear in the search list under certain conditions.
+- Note: For more information about this feature refer to the links in the Traceability tab above.
 
 **Precondition**
 
 1. The server is set to allow account creation in System Console ➜ Authentication ➜ Signup
 2. Permissions are set to allow users to invite team members in System Console ➜ User Management ➜ Permissions
-Note: Permissions can be set for different user levels but for the purposes of these tests set it to allow all users to invite members.
+    - Note: Permissions can be set for different user levels but for the purposes of these tests set it to allow all users to invite members.
 
 **Step 1**
 
 1. Log in as a regular user on a server that allows inviting members
-2. Tap the + sign in the top right corner of the mobile app to open the invite menu at the bottom of the screen
+2. Tap the + sign in the top right corner of the mobile app to open the a menu at the bottom of the screen
+![](https://raw.githubusercontent.com/mattermost/mattermost-test-management/main/data/asset/plus_sign_menu.jpeg)
 3. Tap 'Invite people to the team' in the menu to open the Invite form that fills the screen
 4. Type in a string of characters that you know won't match any user on the server into the field that asks you to "Type a name or email address…"
     
 
 **Expected**
 
-• A box appears below the field you're typing in that reads "No one found matching [what you typed]"
+- A box appears below the field you're typing in that reads "No one found matching [what you typed]"

--- a/data/test-cases/mobile-v2/invite-people/MM-T5361.md
+++ b/data/test-cases/mobile-v2/invite-people/MM-T5361.md
@@ -1,11 +1,12 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Should show no results item in search list"
-status: Draft
+name: "Mobile V2: Invite - Should show no results item in search list"
+status: Active
 priority: Normal
 folder: Invite People
-authors: ""
-team_ownership: []
+authors: "@steve.mudie"
+team_ownership:
+- Growth
 priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
 
 # (Optional)
@@ -37,4 +38,26 @@ steps_hashed: 97f3683db4eaeef5d5531fa7f3da9ca284e8881a87ee4d1267e4dd74c6ed9f072f
 
 ---
 
+**Objective**
+
+Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
+Specifically for this test we need to ensure that no results will appear in the search list under certain conditions.
+Note: For more information about this feature refer to the links in the Traceability tab above.
+
+**Precondition**
+
+1. The server is set to allow account creation in System Console ➜ Authentication ➜ Signup
+2. Permissions are set to allow users to invite team members in System Console ➜ User Management ➜ Permissions
+Note: Permissions can be set for different user levels but for the purposes of these tests set it to allow all users to invite members.
+
 **Step 1**
+
+1. Log in as a regular user on a server that allows inviting members
+2. Tap the + sign in the top right corner of the mobile app to open the invite menu at the bottom of the screen
+3. Tap 'Invite people to the team' in the menu to open the Invite form that fills the screen
+4. Type in a string of characters that you know won't match any user on the server into the field that asks you to "Type a name or email address…"
+    
+
+**Expected**
+
+• A box appears below the field you're typing in that reads "No one found matching [what you typed]"


### PR DESCRIPTION
#### Summary

This fills in the previously missing test steps for the placeholder [MM-T5361](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T5361) regarding https://github.com/mattermost/mattermost-mobile/pull/6877

Specifically for this test we need to ensure that no results will appear in the search list under certain conditions.

Feature Ticket ➜ [MM-42835](https://mattermost.atlassian.net/browse/MM-42835)
[Figma design](https://www.figma.com/file/mvJXgiirM4ucPW8bHAvM4G/MM-39720-Invite-People?node-id=276%3A230414)
[Figma prototype](https://www.figma.com/proto/mvJXgiirM4ucPW8bHAvM4G/MM-39720-Invite-People?page-id=117%3A212251&node-id=206%3A218607&viewport=478%2C48%2C0.15&scaling=min-zoom&starting-point-node-id=206%3A218607&show-proto-sidebar=1)

<a href="https://gitpod.io/#https://github.com/mattermost/mattermost-test-management/pull/59"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

