### PR TITLE
test(MM-T4892): Self-Serve: Downgrade from Professional plan

### DIFF
--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -38,9 +38,25 @@ steps_hashed: e9ee1ad9777f5c4bf5a1a2eb712ef7e206b6417d2ca9d3ce534f49775b9f6d0eab
 
 ---
 
+**Objective**
+
+<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitate downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
+Verify the functionality of the downgrade mechanism/workflow in monthly billed cloud workspaces.  
+
+**Note:** For more information about this feature refer to the links in the Traceability tab of this test case located on Zephyr Scale.
+
+**Precondition**
+
+In order to test this you'll need to do the following in order:  
+1. Create a new Cloud Workspace in the test environment 
+2. Copy the server adddress without the "https://" part (e.g., myserver.test.mattermost.cloud)
+3. Reach out to a developer on the Self-Serve team and explain you need to test downgrading from a monthly subscription  
+
 **Step 1**
 
-1. Upgrade a Workspace to Professional
+**Note:** The developer you reached out to (as described in the Precondition) may set the Workspace as already subscribed to a Professional plan when they make the changes you need to test this. If so you can skip step 1 below.  
+
+1. Upgrade a Workspace to Professional on a monthly plan  
 2. Create a half dozen teams or so
 3. Go to **System Console ➜ Billing & Account ➜ Subscription**
 4. Click the **View plans** button

--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -49,7 +49,7 @@ Verify the functionality of the downgrade mechanism/workflow in monthly billed c
 
 In order to test this you'll need to do the following in order:  
 1. Create a new Cloud Workspace in the test environment 
-2. Copy the server adddress without the "https://" part (e.g., myserver.test.mattermost.cloud)
+2. Copy the server address without the "https://" part (e.g., myserver.test.mattermost.cloud)
 3. Reach out to a developer on the Self-Serve team and explain you need to test downgrading from a monthly subscription  
 
 **Step 1**

--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -40,17 +40,11 @@ steps_hashed: e9ee1ad9777f5c4bf5a1a2eb712ef7e206b6417d2ca9d3ce534f49775b9f6d0eab
 
 **Objective**
 
-<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitate downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
+<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitae downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
 Verify the functionality of the dowgrade mechanism/workflow in monthly billed cloud workspaces.  
 **Note:** For more information about this feature refer to the links in the Traceability tab above.
 
 **Precondition**
-
-You'll need to have a cloud Workspace that has access to purchasing a Professional plan with monthly billing.  
-
-1. Sign up for a new cloud workspce as you normally would
-2. Reach out to a dev on the Self-Serve team and ask them to make the needed changes in Stripe to allow this
-3. After testing is complete let them know so they can toggle it off again for the  test environment.
 
 **Step 1**
 

--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -38,9 +38,17 @@ steps_hashed: e9ee1ad9777f5c4bf5a1a2eb712ef7e206b6417d2ca9d3ce534f49775b9f6d0eab
 
 ---
 
+**Objective**
+
+<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitae downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
+Verify the functionality of the dowgrade mechanism/workflow in monthly billed cloud workspaces.  
+**Note:** For more information about this feature refer to the links in the Traceability tab above.
+
+**Precondition**
+
 **Step 1**
 
-1. Upgrade a Workspace to Professional
+1. Upgrade a Workspace to Professional on a monthly plan
 2. Create a half dozen teams or so
 3. Go to **System Console ➜ Billing & Account ➜ Subscription**
 4. Click the **View plans** button

--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -38,17 +38,9 @@ steps_hashed: e9ee1ad9777f5c4bf5a1a2eb712ef7e206b6417d2ca9d3ce534f49775b9f6d0eab
 
 ---
 
-**Objective**
-
-<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitae downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
-Verify the functionality of the dowgrade mechanism/workflow in monthly billed cloud workspaces.  
-**Note:** For more information about this feature refer to the links in the Traceability tab above.
-
-**Precondition**
-
 **Step 1**
 
-1. Upgrade a Workspace to Professional on a monthly plan
+1. Upgrade a Workspace to Professional
 2. Create a half dozen teams or so
 3. Go to **System Console ➜ Billing & Account ➜ Subscription**
 4. Click the **View plans** button

--- a/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
+++ b/data/test-cases/cloud/signup-trial-and-upgrade/MM-T4892.md
@@ -40,11 +40,17 @@ steps_hashed: e9ee1ad9777f5c4bf5a1a2eb712ef7e206b6417d2ca9d3ce534f49775b9f6d0eab
 
 **Objective**
 
-<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitae downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
+<!-- As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitate downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place. -->
 Verify the functionality of the dowgrade mechanism/workflow in monthly billed cloud workspaces.  
 **Note:** For more information about this feature refer to the links in the Traceability tab above.
 
 **Precondition**
+
+You'll need to have a cloud Workspace that has access to purchasing a Professional plan with monthly billing.  
+
+1. Sign up for a new cloud workspce as you normally would
+2. Reach out to a dev on the Self-Serve team and ask them to make the needed changes in Stripe to allow this
+3. After testing is complete let them know so they can toggle it off again for the  test environment.
 
 **Step 1**
 

--- a/data/test-cases/mobile-v2/invite-people/MM-T5362.md
+++ b/data/test-cases/mobile-v2/invite-people/MM-T5362.md
@@ -1,11 +1,12 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Should be able to send email invite"
-status: Draft
+name: "Mobile V2: Should be able to send email invite"
+status: Active
 priority: Normal
 folder: Invite People
-authors: ""
-team_ownership: []
+authors: "@steve.mudie"
+team_ownership:
+- Growth
 priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
 
 # (Optional)
@@ -37,4 +38,27 @@ steps_hashed: 97f3683db4eaeef5d5531fa7f3da9ca284e8881a87ee4d1267e4dd74c6ed9f072f
 
 ---
 
+**Objective**
+
+- Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
+- Specifically for this test we need to ensure that users are able to send email invitations.
+- **Note**: For more information about this feature refer to the links in the Traceability tab for this test case in Zephyr Scale.
+
+**Precondition**
+
+1. The server is set to allow account creation in System Console ➜ Authentication ➜ Signup
+2. Permissions are set to allow users to invite team members in System Console ➜ User Management ➜ Permissions
+    - Note: Permissions can be set for different user levels but for the purposes of these tests set it to allow all users to invite members.
+
 **Step 1**
+
+1. Log in as a regular user on a server that allows inviting members
+2. Tap the + sign in the top right corner of the mobile app to open the Plus menu at the bottom of the screen
+![](https://raw.githubusercontent.com/mattermost/mattermost-test-management/main/data/asset/plus_sign_menu.jpeg)
+3. Tap 'Invite people to the team' in the menu to open the Invite form that fills the screen
+4. Type in a string of characters that you know won't match any user on the server into the field that asks you to "Type a name or email address…"
+    
+
+**Expected**
+
+- A box appears below the field you're typing in that reads "No one found matching [what you typed]"

--- a/data/test-cases/mobile-v2/invite-people/MM-T5362.md
+++ b/data/test-cases/mobile-v2/invite-people/MM-T5362.md
@@ -1,12 +1,11 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Mobile V2: Should be able to send email invite"
-status: Active
+name: "Should be able to send email invite"
+status: Draft
 priority: Normal
 folder: Invite People
-authors: "@steve.mudie"
-team_ownership:
-- Growth
+authors: ""
+team_ownership: []
 priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
 
 # (Optional)
@@ -38,27 +37,4 @@ steps_hashed: 97f3683db4eaeef5d5531fa7f3da9ca284e8881a87ee4d1267e4dd74c6ed9f072f
 
 ---
 
-**Objective**
-
-- Verify the functionality of the invite mechanism/workflow in the Mobile V2 app.
-- Specifically for this test we need to ensure that users are able to send email invitations.
-- **Note**: For more information about this feature refer to the links in the Traceability tab for this test case in Zephyr Scale.
-
-**Precondition**
-
-1. The server is set to allow account creation in System Console ➜ Authentication ➜ Signup
-2. Permissions are set to allow users to invite team members in System Console ➜ User Management ➜ Permissions
-    - Note: Permissions can be set for different user levels but for the purposes of these tests set it to allow all users to invite members.
-
 **Step 1**
-
-1. Log in as a regular user on a server that allows inviting members
-2. Tap the + sign in the top right corner of the mobile app to open the Plus menu at the bottom of the screen
-![](https://raw.githubusercontent.com/mattermost/mattermost-test-management/main/data/asset/plus_sign_menu.jpeg)
-3. Tap 'Invite people to the team' in the menu to open the Invite form that fills the screen
-4. Type in a string of characters that you know won't match any user on the server into the field that asks you to "Type a name or email address…"
-    
-
-**Expected**
-
-- A box appears below the field you're typing in that reads "No one found matching [what you typed]"


### PR DESCRIPTION
#### Summary

This is a minor update to the existing test case [MM-T4892](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T4892)

As of the Cloud release on February 2, 2023 new customers will no longer be able to select monthly as a billing option. As such they will not be able to downgrade manually and will instead need to contact support to facilitate downgrading. Grandfathered monthly billed customers will retain the ability to downgrade so for now this test can remain in place as we can, and still need to test it.

<a href="https://gitpod.io/#https://github.com/mattermost/mattermost-test-management/pull/65"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

