### PR TITLE
test: discard message edits after cancelling

### DIFF
--- a/data/test-cases/channels/messaging/cancel-message-editing.md
+++ b/data/test-cases/channels/messaging/cancel-message-editing.md
@@ -1,0 +1,51 @@
+---
+# (Required) Ensure all values are filled up
+name: "Should discard any changes made after cancelling the edit and opening the edit textbox again should display the original message"
+status: Active
+priority: Normal
+folder: Messaging
+authors: "@collinewait"
+team_ownership:
+- Channels
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Messaging
+component: null
+tags: []
+labels: []
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+<https://mattermost.atlassian.net/browse/MM-50746>
+
+Should discard any changes made after cancelling the edit and opening the edit textbox again should display the original message
+
+1. Post a message in a channel
+2. Hit 'arrow-up' to open the edit box
+3. Edit the message
+4. Press ESC to cancel the edit
+5. Hit 'arrow-up' again to open the edit box
+
+**Expected**
+
+After step 5 verify the following
+
+- The edit box should open with the original message

--- a/data/test-cases/channels/messaging/cancel-message-editing.md
+++ b/data/test-cases/channels/messaging/cancel-message-editing.md
@@ -36,8 +36,6 @@ steps_hashed: null
 
 <https://mattermost.atlassian.net/browse/MM-50746>
 
-Should discard any changes made after cancelling the edit and opening the edit textbox again should display the original message
-
 1. Post a message in a channel
 2. Hit 'arrow-up' to open the edit box
 3. Edit the message


### PR DESCRIPTION
<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary
Should discard edits made to messages after cancelling

#### Is the feature in stable branch or under review?
- [x] Feature still under review? If yes, list all related pull requests for reference. https://github.com/mattermost/mattermost-webapp/pull/12253

#### Test server
<!--
Link the test server to be used for testing and trying out the test cases could be from "/cloud", pull request or requirements to set up the test server.
-->

#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
