### PR TITLE
test(T899): Update to Privacy Policy link in System Console ➜ Edition & License

### DIFF
--- a/data/test-cases/suite/system-console/about/MM-T899.md
+++ b/data/test-cases/suite/system-console/about/MM-T899.md
@@ -4,7 +4,7 @@ name: "Edition and License: Verify Privacy Policy link points to correct URL"
 status: Active
 priority: Low
 folder: About
-authors: ""
+authors: "Steve Mudie"
 team_ownership: 
 - Suite Users
 priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
@@ -49,13 +49,9 @@ steps_hashed: 281a6f9949f1650ab54e0b41e76b804bb89a1a41fb09dc0d38fca95cef46b27bb5
 
 **Note**: We don't currently test anything on this page, but removing and re-adding a license is included in other tests
 
-1. Click on Privacy Policy link
-2. Verify the link points to https\://about.mattermost.com/default-privacy-policy/
-
-_Related ticket(s):_
-
-[Update Privacy policy link in System Console > Enterprise & License — MM-19873](https://mattermost.atlassian.net/browse/MM-19873)
+1. Click on the Privacy Policy link at the bottom of System Console ➜ Edition & License 
+2. Verify the link points to `https://mattermost.com/privacy-policy/`
 
 **Expected**
 
-- The Privacy Policy link in System Console > Edition & License should link to https\://about.mattermost.com/default-privacy-policy/
+- The Privacy Policy link in System Console ➜ Edition & License should link to `https://mattermost.com/privacy-policy/`


### PR DESCRIPTION
### Summary
- Updating the link to reflect the current location on the site
- Removing the old "Related ticket(s)" link as well since we have it linked in the Traceability tab still

#### Zephyr Scale test case
[MT899 - Edition and License: Verify Privacy Policy link points to correct URL](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/MM-T899)
