### PR TITLE
[MI-3546]: Added the test cases of Jira release 4.1.0 (#4)

### DIFF
--- a/data/test-cases/plugins/jira/jira-server/general-slash-commands/Jira_about.md
+++ b/data/test-cases/plugins/jira/jira-server/general-slash-commands/Jira_about.md
@@ -1,0 +1,40 @@
+# (Required) Ensure all values are filled up
+name: "Jira about"
+status: Active
+priority: Normal
+folder: General slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+Run the /jira about slash command.
+
+**Expected**
+
+The user should be presented with the information of Jira version and when it was installed.

--- a/data/test-cases/plugins/jira/jira-server/general-slash-commands/Jira_setup.md
+++ b/data/test-cases/plugins/jira/jira-server/general-slash-commands/Jira_setup.md
@@ -1,0 +1,40 @@
+# (Required) Ensure all values are filled up
+name: "Jira setup"
+status: Active
+priority: Normal
+folder: General slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+Write the /jira setup slash command.
+
+**Expected**
+
+The setup command should be visible in the autocomplete list.

--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Create_issue.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Create_issue.md
@@ -1,0 +1,43 @@
+# (Required) Ensure all values are filled up
+name: "Create issue modal"
+status: Active
+priority: Normal
+folder: General slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Post any new message in the channel.
+2. Click on the create issue option in post menu actions.
+3. Select any project and fill the following fields.
+4. Change the project afterwards.
+
+**Expected**
+
+The modal should not close, instead it should adjust itself for a new entry after changing the selected project.


### PR DESCRIPTION
## Summary

This PR contains the test case for the followings:-

- [Add built info via /jira about (](https://github.com/mattermost/mattermost-plugin-jira/commit/7c1b921343f583c9d16fbe06463d5c6f58ad80fe)[#916](https://github.com/mattermost/mattermost-plugin-jira/pull/916)[)](https://github.com/mattermost/mattermost-plugin-jira/commit/7c1b921343f583c9d16fbe06463d5c6f58ad80fe)
- [Adding /setup to autocomplete (GitHub issue](https://github.com/mattermost/mattermost-plugin-jira/commit/2acc681c38a13e5b093004bbabc2ae6467f643ae) [#892](https://github.com/mattermost/mattermost-plugin-jira/issues/892)[) (](https://github.com/mattermost/mattermost-plugin-jira/commit/2acc681c38a13e5b093004bbabc2ae6467f643ae)[#898](https://github.com/mattermost/mattermost-plugin-jira/pull/898)[)](https://github.com/mattermost/mattermost-plugin-jira/commit/2acc681c38a13e5b093004bbabc2ae6467f643ae)
- [[GH-819]:Create issue modal crashes when assignee is selected before switching projects (#879)](https://github.com/mattermost/mattermost-plugin-jira/commit/ba4e35106f04225e38e8b9679f684d4b707a0ad9)