### PR TITLE
Added tests to validate security level filter.

### DIFF
--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/No Security Group Option Shown When Project Has No Security Groups.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/No Security Group Option Shown When Project Has No Security Groups.md
@@ -1,0 +1,44 @@
+---
+# (Required) Ensure all values are filled up
+name: "No security group options shown when a project has no security groups available"
+status: Active
+priority: Normal
+folder: Jira subscriptions
+authors: "@DHaussermann"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. In Jira, create or locate a target project that has no security groups associated to it
+2. In matter most select a channel and create a new susbscription
+3. Select the target project from step 1. and add some events
+4. Add a filter and select Secutiy Group
+
+**Expected**
+
+No options are available in security groups

--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group but no filter is included in the subscription.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group but no filter is included in the subscription.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "No security group options shown when a project has no security groups available"
+status: Active
+priority: Normal
+folder: Jira subscriptions
+authors: "@DHaussermann"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. In Jira, create or locate a target project has a set of security groups associated to it
+2. In matter most select a channel and create a new susbscription
+3. Select the target project from step 1. and add some events
+4. Save the subscirption without adding a filter
+5. In jira trigger an event included in the subsription
+
+**Expected**
+
+- Above the "approximate SQL" box the text '"security level" is empty' is shown
+- The even is not delivered as there is not security level applied

--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group that is included.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group that is included.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "No security group options shown when a project has no security groups available"
+status: Active
+priority: Normal
+folder: Jira subscriptions
+authors: "@DHaussermann"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. In Jira, create or locate a target project has a set of security groups associated to it
+2. In matter most select a channel and create a new susbscription
+3. Select the target project from step 1. and add some events
+4. Add one of the the security levels for the project
+5. In jira locate (or create) an issue that is part of the security level selected in the filter above
+6. For the Jira issue above, trigger an event included in the subsription
+
+**Expected**
+
+The event is delivered as the security group matches

--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group that is not included.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Project has a security group that is not included.md
@@ -1,0 +1,45 @@
+---
+# (Required) Ensure all values are filled up
+name: "No security group options shown when a project has no security groups available"
+status: Active
+priority: Normal
+folder: Jira subscriptions
+authors: "@DHaussermann"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. In Jira, create or locate a target project has a set of security groups associated to it
+2. In matter most select a channel and create a new susbscription
+3. Select the target project from step 1. and add some events
+4. Add one of the the security levels for the project
+5. In jira locate (or create) an issue that is part of the security level no selected in the filter above
+6. For the Jira issue above, trigger an event included in the subsription
+
+**Expected**
+The even is not delivered as the security level is outside the scope of the subscription

--- a/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Subscriptions deliver without Security group filter when a project has no security groups availabl.md
+++ b/data/test-cases/plugins/jira/jira-server/jira-subscriptions/Subscriptions deliver without Security group filter when a project has no security groups availabl.md
@@ -1,0 +1,44 @@
+---
+# (Required) Ensure all values are filled up
+name: "No security group options shown when a project has no security groups available"
+status: Active
+priority: Normal
+folder: Jira subscriptions
+authors: "@DHaussermann"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. In Jira, create or locate a target project that has no security groups associated to it
+2. In matter most select a channel and create a new susbscription
+3. Select the target project from step 1. and add some events
+4. Save the subscirption without adding a filter
+5. In jira trigger an event included in the subsription
+   **Expected**
+
+The event is delivered in the channel


### PR DESCRIPTION
This set of tests will validate that the Jira security level filter is work as expected
 
There are existing tests for filters but they pre-date a change making security level a required filter when trying to deliver details from Jira that have security level associated with them.

#### Is the feature in stable branch or under review?
- [x] Feature in stable branch (master, main)?
- [] Feature still under review? If yes, list all related pull requests for reference.


#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
- [x] Browser
- [] Mobile App (version, OS)
- [x] Desktop App (version, OS)