### PR TITLE
Replaced legacy GitBook URLs with PL links

### DIFF
--- a/data/test-cases/plugins/confluence/MM-T3982.md
+++ b/data/test-cases/plugins/confluence/MM-T3982.md
@@ -59,7 +59,7 @@ Confluence Cloud or Server is available
 
 **Step 2**
 
-Install the confluence plugin onto a Mattermost test server using these instructions https\://mattermost.gitbook.io/plugin-confluence
+Install the confluence plugin onto a Mattermost test server using these instructions https\://mattermost.com/pl/mattermost-plugin-confluence
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/general/MM-T4632.md
+++ b/data/test-cases/plugins/zoom/general/MM-T4632.md
@@ -48,7 +48,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/general/MM-T4633.md
+++ b/data/test-cases/plugins/zoom/general/MM-T4633.md
@@ -48,7 +48,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/general/MM-T4965.md
+++ b/data/test-cases/plugins/zoom/general/MM-T4965.md
@@ -47,7 +47,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 
@@ -65,7 +65,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/jwt/MM-T4630.md
+++ b/data/test-cases/plugins/zoom/jwt/MM-T4630.md
@@ -49,7 +49,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/jwt/MM-T4631.md
+++ b/data/test-cases/plugins/zoom/jwt/MM-T4631.md
@@ -49,7 +49,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4628.md
+++ b/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4628.md
@@ -48,7 +48,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4629.md
+++ b/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4629.md
@@ -47,7 +47,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4634.md
+++ b/data/test-cases/plugins/zoom/oauth-account-level-app/MM-T4634.md
@@ -48,7 +48,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4624.md
+++ b/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4624.md
@@ -47,7 +47,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses User-managed app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-user-level-app>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4625.md
+++ b/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4625.md
@@ -46,7 +46,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses User-managed app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-user-level-app>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4626.md
+++ b/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4626.md
@@ -48,7 +48,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses User-managed app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-user-level-app>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4627.md
+++ b/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4627.md
@@ -50,7 +50,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses User-managed app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-user-level-app>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 

--- a/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4635.md
+++ b/data/test-cases/plugins/zoom/oauth-user-managed-app/MM-T4635.md
@@ -49,7 +49,7 @@ _Important notes about this step:_
 
 This test requires an oAuth app on the Zoom side that uses Account-level app\
 \
-See steps here <https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration/zoom-setup-oauth>
+See steps here <https://mattermost.com/pl/mattermost-plugin-zoom>
 
 **Expected**
 


### PR DESCRIPTION
Replaced legacy/broken GitBook links with permalinks [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436