### PR TITLE
[MM-61]: Added the test cases for reopened event on the Github and excluded repositories in an organization.

### DIFF
--- a/data/test-cases/plugins/github/subscriptions/Exclude_subscriptions_for_repo.md
+++ b/data/test-cases/plugins/github/subscriptions/Exclude_subscriptions_for_repo.md
@@ -1,0 +1,48 @@
+---
+# (Required) Ensure all values are filled up
+name: "Excluding subscription in the channel or DM/GM on MM for a repository in a organization "
+status: Active
+priority: Normal
+folder: Subscriptions
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Enter the slash command `/github subscriptions add <organization> --feature <events> --exclude <repository>` in the desired channel or DM/GM on MM and create a subscription for an organization with more than one repository and exclude any desired repository in that organization.
+2. Trigger any desired event in the excluded repository on the Github and navigate to the desired channel or DM/GM on MM.
+
+**Step 2**
+
+1. Enter the slash command `/github subscriptions add <organization> --feature <events> --exclude <repository>` in the desired channel or DM/GM on MM and create a subscription for an organization with more than one repository and exclude any desired repository in that organization.
+2. Trigger any desired event in any desired repository except the excluded ones on the Github and navigate to the desired channel or DM/GM on MM.
+
+**Expected**
+
+No notification should be generated for the triggered event in the desired channel or DM/GM on MM.
+After step 2, notification of the triggered event should be shown in the desired channel or DM/GM on MM.

--- a/data/test-cases/plugins/github/subscriptions/Re-opened_PR_notification.md
+++ b/data/test-cases/plugins/github/subscriptions/Re-opened_PR_notification.md
@@ -1,0 +1,43 @@
+---
+# (Required) Ensure all values are filled up
+name: "Message in the channel or DM/GM on MM regarding the event for reopening a PR on the github"
+status: Active
+priority: Normal
+folder: Subscriptions
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Enter the slash command `/github subscription add <repo or organization> --feature pulls` in any desired channel or DM/GM and create subscription for the desired repo or organization on MM.
+2. Create and close a PR or close any existing PR in the subscribed desired repository or in any repository of the subscribed desired organization on Github.
+3. Reopen the closed PR on Github and navigate to the subscribed channel or DM/GM on MM.
+
+**Expected**
+
+The user should get the notification in the subscribed desired channel or DM/GM on MM, regarding the desired PR reopened. 


### PR DESCRIPTION
###Summary
This PR consists the test cases for the following scenarios,

- Excluded repositories while creating subscriptions for a organization on MM.
- Notification for reopened PR event on Github.