### PR TITLE
Update MM-T847.md to remove unneeded checks for channel order

### DIFF
--- a/data/test-cases/channels/channels/MM-T847.md
+++ b/data/test-cases/channels/channels/MM-T847.md
@@ -53,15 +53,7 @@ steps_hashed: 27fdfd4fff43685f887e0f2968d2dabafacd5444d94240b96b99a2c94c3a9f3cce
 
 2. Type the beginning of a channel name in the `Jump to...` search box
 
-3. Verify relevant results are displayed in these categories, in this order (when filtered):
-
-   - Unreads
-   - Direct messages
-   - Channels (public and private together, listed alphabetically. Favorites are listed together here too; not sorted separately)
-   - Members (other users you don't already have a DM with)
-   - Not a Member (public channels you don't belong to)
-
-4. Tap on the name of a channel from the filtered list
+3. Tap on the name of a channel from the filtered list
 
 _Related ticket(s):_
 
@@ -69,4 +61,4 @@ _Related ticket(s):_
 
 **Expected**
 
-- View changes to the channel you have tapped on
+- The channel you tapped on opens in view


### PR DESCRIPTION
Removed extra info about channel order, which isn't at the core of this test case and depends on config anyway.