### PR TITLE
Update teamOptions list

### DIFF
--- a/src/util/test_case.ts
+++ b/src/util/test_case.ts
@@ -191,6 +191,7 @@ function customFieldsValues() {
       'Growth',
       'Integration Frameworks',
       'Mobile Platform',
+      'MS Teams',
       'Playbooks',
       'QA Platform',
       'Self-Serve',

--- a/src/util/test_case.ts
+++ b/src/util/test_case.ts
@@ -183,12 +183,17 @@ function customFieldsValues() {
   const teamOptions = {
     default: [changeRequired],
     options: [
+      'ABC',
       'Boards',
       'Calls',
       'Channels',
+      'Cloud Platform',
+      'Customer Reliability Engineering',
       'Data Eng',
+      'Deployment Engineering',
       'Desktop Platform',
       'Growth',
+      'ICU',
       'Integration Frameworks',
       'Mobile Platform',
       'MS Teams',
@@ -198,7 +203,7 @@ function customFieldsValues() {
       'Suite Users',
       'Server Platform',
       'Web Platform',
-      'ICU',
+      'XYZ',
     ],
   };
 


### PR DESCRIPTION
Updating teamOptions list to add current teams available in Jira. Did not remove old teams as that could affect existing tests; those should be updated in a targeted way. 

To avoid validation failures such as on https://github.com/mattermost/mattermost-test-management/pull/168

Adding:
```
ABC
Cloud Platform
Customer Reliability Engineering
Deployment Engineering
Integrations
MS Teams
XYZ
```