### PR TITLE
chore: remove codeowner except for .github/workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-/src/ @saturninoabril
-.github/ @saturninoabril
+.github/workflows @mattermost/qa-core-team @mattermost/core-build-engineers


### PR DESCRIPTION
#### Summary
Removed codeowners to all folders to unblock developers except at `.github/workflows` which is assigned to QA core and build engineers. Ref: https://github.com/mattermost/mattermost-test-management/pull/168#issuecomment-2027677122

Note: This PR is awaiting for the separate PR in GH management. Will remove "do not merge" label once merged.