### PR TITLE
[chore] migration of plugin-store

### DIFF
--- a/data/test-cases/plugins/MM-T2400.md
+++ b/data/test-cases/plugins/MM-T2400.md
@@ -46,10 +46,10 @@ steps_hashed: f797e98dc9de2428b47143aa3f9fafe7990285feb1c6e7081d41dc4b396ba541a9
 
 Plugins Management\
 ————————————————————————————\
-First get latest demo-plugin at https\://plugins-store.test.mattermost.com/ci/mattermost-plugin-demo-ci.tar.gz\\
+First get latest demo-plugin at https\://plugins.releases.mattermost.com/ci/mattermost-plugin-demo-ci.tar.gz\\
 
 1. Plugins ➜ Management
-2. Click to upload a plugin - use latest demo-plugin.tar.gz; download from <https://plugins-store.test.mattermost.com/ci/mattermost-plugin-demo-ci.tar.gz>
+2. Click to upload a plugin - use latest demo-plugin.tar.gz; download from <https://plugins.releases.mattermost.com/ci/mattermost-plugin-demo-ci.tar.gz>
 3. Refresh the webapp
 4. Click to enable the demo plugin
 

--- a/data/test-cases/plugins/plugin-marketplace/MM-T3452.md
+++ b/data/test-cases/plugins/plugin-marketplace/MM-T3452.md
@@ -63,7 +63,7 @@ Both these tools can be installed with Brew if you have MacOs.
 Download link shown in ngrok shows as
 
 ```
-https://plugins-store.test.mattermost.com/release/mattermost-plugin-<your plugin>-v0.1.2-linux-amd64.tar.gz
+https://plugins.releases.mattermost.com/release/mattermost-plugin-<your plugin>-v0.1.2-linux-amd64.tar.gz
 ```
 
 ---
@@ -86,5 +86,5 @@ Both these tools can be installed with Brew if you have MacOs.
 Download link shown in ngrok shows as
 
 ```
-https://plugins-store.test.mattermost.com/release/mattermost-plugin-<your plugin>-v0.1.2-osx-amd64.tar.gz
+https://plugins.releases.mattermost.com/release/mattermost-plugin-<your plugin>-v0.1.2-osx-amd64.tar.gz
 ```


### PR DESCRIPTION


<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary
<!--
A description of this pull request.
-->

Plugin store is gradually migrated from:
- https://plugins-store.test.mattermost.com to
- https://plugins.releases.mattermost.com

We reflect that change here

Note: Currently both CDN's are working as expected, to facilitate the mgiration. Upon succesfull migration, https://plugins-store.test.mattermost.com will be decomissioned

