### PR TITLE
test(ABAC-system-admin): Add ABAC system admin test cases

### DIFF
--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5782.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5782.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: "System admin can enable or disable system-wide attribute-based access"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239112010
+key: MM-T5782
+created_on: "2025-05-21T01:02:45Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 06c4d289b47932db1c028b7fd998a634a238f675f27b54b4045eec99a12846f080bd257e7003419e842086a1a4f81675
+steps_hashed: 15c9d033fadb91c419c127d010bf4435ffadb075ac9bbb2622c5c1f78f37e61637fbce52b195a7959acd5cade29ca520
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5782: System admin can enable or disable system-wide attribute-based access
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+On a server with Enterprise Advanced (aka Premium) license:\
+1\. Log in as system admin, view Attribute-based access page in System Console under User Management section\
+2\. Click to enable Attribute-based access, observe controls on page are functional and if policies exist they are enacted as specified\
+3\. Click to disable Attribute-based access, observe controls on page are not functional and if policies exist they are not enacted
+
+**Expected**
+
+When enabled by system admin, configuration is editable and policies are enacted. When disabled by system admin, configuration is not editable and policies are not enacted.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5783.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5783.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy created in System Console controls access as specified (one attribute, `= is`, without auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239113248
+key: MM-T5783
+created_on: "2025-05-21T01:54:08Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: ab10b5ae875dc0b39941c5d7f41374741aaf8c203e6865fbf855aafce71b3ddea89a672ed34803e6ca427bbe56277b42
+steps_hashed: e3c8c11087260e5c4101d23ad0b3cde795684a804304e7ca8fa3d415d9a3c6baeef7fb7dc997110c8eea48ee445b1570
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5783: Attribute-based access policy created in System Console controls access as specified (one attribute, `= is`, without auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, leave auto-add set to False\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Click Test Access Rule, observe users are listed who satisfy the policy\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy but is not yet in the channel observe that they are not auto-added\
+6\. Have a user who satisfies the policy and is already in the channel observe no change\
+7\. Have a user who does not satisfy the policy and is already in the channel observe that they are auto-removed from the channel (auto-add setting only refers to adding; noncompliant users are still removed)\
+8\. As system admin in the channel you are able to add the user who satisfies the policy to the channel
+
+**Expected**
+
+\- User who satisfies the policy is not auto-added, but is able to be added by a user with permission in that channel\
+\- User who does not satisfy the policy is auto-removed

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5784.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5784.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy created in System Console controls access as specified (one attribute, `= is`, with auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239116530
+key: MM-T5784
+created_on: "2025-05-21T03:25:21Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 320f536610dcdb38f365648e8d840a334fb4dc28e50d4defb1bd33acd66cc0790764a0b2e8679f11a310c3b0121a0444
+steps_hashed: a2253c513ffab7e77a205e4b2f594911d7ddec5bf7ac364c0a7b753ceacc3d3fda383efa02b4bdd17c3f656841c0bdcb
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5784: Attribute-based access policy created in System Console controls access as specified (one attribute, `= is`, with auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Click Test Access Rule, observe users are listed who satisfy the policy\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy but is not yet in the channel observe that they are auto-added\
+6\. Have a user who satisfies the policy and is already in the channel observe no change\
+7\. Have a user who does not satisfy the policy and is already in the channel observe that they are auto-removed from the channel (auto-add setting only refers to adding; noncompliant users are still removed)
+
+**Expected**
+
+\- User who satisfies the policy is auto-added\
+\- User who does not satisfy the policy is auto-removed\
+\- \`User added\` and \`User removed\` system messages are posted in the channel

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5785.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5785.md
@@ -1,0 +1,69 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy that uses all the attribute types, including multi-select with multiple values, controls access as specified (multiple attributes, `= is`, with auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239116836
+key: MM-T5785
+created_on: "2025-05-21T03:31:24Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 3a99905d7611ce35e96ce060bc71bae9d2932ff5a9d0a37087b26b0c860440273a64a87f2c710fd734e7281e3bb95031
+steps_hashed: c0cb3f544820ef98f18ee10dd347e151f539a05dc72db6c8538a303eeb934f4ad8a2e57d4e60bc38f595932010cbd39e
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5785: Attribute-based access policy that uses all the attribute types, including multi-select with multiple values, controls access as specified (multiple attributes, `= is`, with auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value\
+3\. Repeat so all attribute types are used:\
+\- Text\
+\- Phone\
+\- URL\
+\- Select\
+\- Multiple Select (include multiple qualifying values)\
+4\. Click Test Access Rule, observe users are listed who satisfy the policy\
+5\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+6\. Have a user who satisfies the policy but is not yet in the channel observe that they are auto-added\
+7\. Have a user who satisfies the policy and is already in the channel observe no change\
+8\. Have a user who meets only some of the rules and is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the multi-rule policy with multiple attribute types is auto-added.\
+User who does not satisfy all rules in the policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5786.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5786.md
@@ -1,0 +1,127 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy using operator variations in Simple mode controls access as specified (one attribute, various operators, with auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239117039
+key: MM-T5786
+created_on: "2025-05-21T03:36:27Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 575e013a38f63d8e010acd1348dee6e8e6deb5d4c5b16ec2d05776676338e137fd9bb85c47e55f71fa90d699a3302e5f
+steps_hashed: 132f203f96d9901a46dfe6c841e895d618aa3df135f7ee00792732534d8e248ccc9736269b2f68f80dcbe671cc59c8ff
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5786: Attribute-based access policy using operator variations in Simple mode controls access as specified (one attribute, various operators, with auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Change operator to \`=! is not\`\
+4\. Click Test Access Rule, observe users are listed who satisfy the policy\
+5\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+6\. Have a user who satisfies the policy using that specific operator but is not yet in the channel observe that they are auto-added\
+7\. Have a user who does not satisfy the policy using that specific operator and who is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the policy is auto-added.\
+User who does not satisfy the policy is auto-removed.
+
+---
+
+**Step 2**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Change operator to \`∈ in\`\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy using that specific operator but is not yet in the channel observe that they are auto-added\
+6\. Have a user who does not satisfy the policy using that specific operator and who is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the policy is auto-added.\
+User who does not satisfy the policy is auto-removed.
+
+---
+
+**Step 3**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Change operator to \`ƒ starts with\`\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy using that specific operator but is not yet in the channel observe that they are auto-added\
+6\. Have a user who does not satisfy the policy using that specific operator and who is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the policy is auto-added.\
+User who does not satisfy the policy is auto-removed.
+
+---
+
+**Step 4**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Change operator to \`ƒ ends with\`\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy using that specific operator but is not yet in the channel observe that they are auto-added\
+6\. Have a user who does not satisfy the policy using that specific operator and who is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the policy is auto-added.\
+User who does not satisfy the policy is auto-removed.
+
+---
+
+**Step 5**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Select policy values: Attribute, Operator, and Value (just one)\
+3\. Change operator to \`ƒ contains\`\
+4\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+5\. Have a user who satisfies the policy using that specific operator but is not yet in the channel observe that they are auto-added\
+6\. Have a user who does not satisfy the policy using that specific operator and who is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the policy is auto-added.\
+User who does not satisfy the policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5787.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5787.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy created using Advanced Mode, with complex rules structure, controls access as specified"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239117476
+key: MM-T5787
+created_on: "2025-05-21T03:59:36Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: dccc9ec59e09642c9010bd87e7516acea7ba3762e7e7790ee8800aacd4de2046f0ffb582611f7af3fd677fc32d466a46
+steps_hashed: fdc9e43b70669b58539b8230a6482586e233d57df45fc35613ad1b26ebaccec095c004398e0591807b7e13f5b8444f10
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5787: Attribute-based access policy created using Advanced Mode, with complex rules structure, controls access as specified
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. As system admin, go to Attribute-Based Access page in System Console and click Add policy. In policy view, enter policy name, set Auto-add to True\
+2\. Switch to Advanced Mode\
+3\. Enter a relatively complex access expression, such as:\
+\
+4\. Click Test Access Rule, observe users are listed who satisfy the policy\
+5\. Click Add channels and select a channel to add, then save (private channels only in first iteration)\
+6\. Have a user who satisfies the policy but is not yet in the channel observe that they are auto-added\
+7\. Have a user who meets only some of the rules and is already in the channel observe that they are auto-removed from the channel
+
+**Test Data**
+
+\- Test || (or) with multiple conditions\
+\- Test using () to group conditions\
+From the Advanced UI: “Write rules like user.\<attribute> == \<value>. Use && / || (and/or) for multiple conditions. Group conditions with ().”
+
+**Expected**
+
+User who satisfies the multi-rule policy with multiple attribute types is auto-added.\
+User who does not satisfy all rules in the policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5788.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5788.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: "Add attribute-based policy to a channel from Channel Configuration page"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239120174
+key: MM-T5788
+created_on: "2025-05-21T04:40:51Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 18e8b1dd7fa4b9d373346ed3645414cd26bb501929f54bc958a0f07fac8c4060c27ff7adb5f1e2db354b258c18adf6a0
+steps_hashed: d52f3c1e67c629591ea563755ab486f3fb955f85f9bca83430f97d47d1c2e97afa8b24a48a457e9898831e0b12127aa6
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5788: Add attribute-based policy to a channel from Channel Configuration page
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server:\
+1\. As admin go to System Console > User Management > Channels\
+2\. Click a channel that is currently listed with Management as \`Manual Invites\` (only private channel in first iteration)\
+3\. Under Channel Management, toggle on \`Enable attribute based channel access\`\
+4\. Select a policy and click Save
+
+**Test Data**
+
+Current notes:\
+When adding a policy to a channel from the Channel Configuration page:\
+\
+Click to toggle on Enable attribute based channel access\
+Click Save without selecting a policy first\
+Right now it appears to save, it closes the Configuration page and returns to the Channels list page. But no changes were made, and no feedback was given to the user about what happened or didn't happen.\
+\
+Should the Channel Configuration page show an error and prevent saving if Save is clicked without selecting a policy?\
+\
+Also, ​after selecting a policy and clicking Save, should ​it say which users will be affected, like the Test User Access button on the other page? And do the changes take effect immediately?
+
+**Expected**
+
+User who satisfies the policy is not auto-added, but is able to be added by a user with permission in that channel.\
+User ​who does not satisfy the policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5789.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5789.md
@@ -1,0 +1,73 @@
+---
+# (Required) Ensure all values are filled up
+name: "Channel cannot use attribute-based policies if it is already constrained by LDAP group sync"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239120925
+key: MM-T5789
+created_on: "2025-05-21T05:02:08Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 2c71073eb45661e48d922a5e67a034c67a9b7e02db0a62ff624769a3372742109511443b3ded01ce8544db1fa1449fb0
+steps_hashed: 134e0d387da78eeda7ba072762119f37f79737242be5a83477b65c750f7b67b5a52d3b2c6500ecbe9f12e01336257d59
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5789: Channel cannot use attribute-based policies if it is already constrained by LDAP group sync
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server and at least one channel configured to be constrained by LDAP group sync:\
+1\. As admin go to System Console > User Management > Channels\
+2\. Click a channel that is currently listed with Management as \`Group Sync\` (only private channel in first iteration)\
+3\. Under Channel Management, observe that \`Enable attribute based channel access\` is not available\
+4\. Toggle off \`Sync Group Members\` and ​observe \`Enable attribute based channel access\` appears and is available to ​toggle on
+
+**Expected**
+
+Attribute-based channel access is not available for a channel that is already set to use LDAP group sync
+
+---
+
+**Step 2**
+
+With at least one policy in existence on the server and at least one channel configured to be constrained by LDAP group sync:\
+1\. As admin go to System Console > User Management > Attribute-Based Access\
+2\. Click a policy to edit it, click Add channels\
+3\. Select a channel you know is constrained by LDAP group sync
+
+**Test Data**
+
+Then what should happen? Currently, the UI allows it to be saved, ​and ​edit mode closes as if it saves, but the channel is not added to the policy, and no feedback is given to the user about what did or did not happen. Should the user be prevented at some point from selecting a channel that ​uses ​LDAP group sync? Or ​it fails to save and prints an error explaining why?

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5790.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5790.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: "Editing value of existing attribute-based access policy applies access control as specified (without auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239123515
+key: MM-T5790
+created_on: "2025-05-21T05:40:10Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: c63ff11981872fe1e6c4bff3758828694b6425092ed06a552dbe2dbc50ebc1ee48a7e18b4a923a504fd9d01a51f13b51
+steps_hashed: d512e4700b36f1a4d4ce384529d7bb25829bc0ebee7fbcc8ab930faa45fde794ad6bcfb893efb98ccb50090243c22d79
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5790: Editing value of existing attribute-based access policy applies access control as specified (without auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server:\
+1\. As system admin, go to Attribute-Based Access page in System Console and click a policy to edit. Ensure Auto-add is set to False\
+2\. Edit an existing policy rule to a different value (same attribute and operator as before)\
+3\. Click Test Access Rule, observe users are listed who satisfy the policy\
+4\. Save the changes\
+5\. Have a user who satisfies the newly edited policy but is not yet in the channel observe that they are not auto-added\
+6\. Have a user who does not satisfy the newly edited policy and is already in the channel observe that they are auto-removed from the channel\
+7\. As system admin in the channel you are able to add the user who satisfies the newly edited policy to the channel
+
+**Expected**
+
+User who satisfies the newly edited policy is not auto-added, but is able to be added by a user with permission in that channel.\
+User who does not satisfy the newly edited policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5791.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5791.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "Editing existing access policy to add another attribute applies access control as specified (with auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239124062
+key: MM-T5791
+created_on: "2025-05-21T05:48:28Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: c69ff846e2a470ed353f1cd6208736840920faa266e6e5842333f189c49a38eb5c968578fd1e2ff5d6680d6357679c43
+steps_hashed: 289d33b08f27524f1aedbb65bc3129c70a21ba2ce0224d4aab8809435f3f2bb6c5982271b3e849514dd08959008d640b
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5791: Editing existing access policy to add another attribute applies access control as specified (with auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server:\
+1\. As system admin, go to Attribute-Based Access page in System Console and click a policy to edit. Ensure Auto-add is set to True\
+2\. Edit an existing policy rule to add another attribute / value\
+3\. Click Test Access Rule, observe users are listed who satisfy the policy\
+4\. Save the changes\
+5\. Have a user who satisfies the newly edited policy but is not yet in the channel observe that they are auto-added\
+6\. Have a user who does not satisfy the newly edited policy and is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the newly edited policy is auto-added to the channel.\
+User who does not satisfy the newly edited policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5792.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5792.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "Editing existing access policy to remove one of the rules applies access control as specified (with auto-add)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239124424
+key: MM-T5792
+created_on: "2025-05-21T05:52:02Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 4712ca25446b3e04c2d19b496c0a16ed9f06fe845d050afc85ca8f894205485b6783b4b3337270e9c203644976963404
+steps_hashed: b4f50eb32bcff3ed0ce98500da5f96b0d78be4224775a8d0b4a1f3893c93d2708df6789c811b54dd8172f0d381cfe233
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5792: Editing existing access policy to remove one of the rules applies access control as specified (with auto-add)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server that has multiple rules:\
+1\. As system admin, go to Attribute-Based Access page in System Console and click a policy to edit. Ensure Auto-add is set to True\
+2\. Edit an existing policy rule to remove one of the rules (attribute/value)\
+3\. Click Test Access Rule, observe users are listed who satisfy the policy\
+4\. Save the changes\
+5\. Have a user who satisfies the newly edited policy but is not yet in the channel observe that they are auto-added\
+6\. Have a user who no longer satisfies the newly edited policy and is already in the channel observe that they are auto-removed from the channel
+
+**Expected**
+
+User who satisfies the newly edited policy is auto-added to the channel.\
+User who does not satisfy the newly edited policy is auto-removed.

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5793.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5793.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "Attribute-based access policy cannot be deleted if it is applied to any channels"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239124665
+key: MM-T5793
+created_on: "2025-05-21T05:54:45Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 6d835252ed3e1afecf0d0d054f69926f1762f36e287086f955e087d88478f5c35203580df0cdca41eba8de278e426afb
+steps_hashed: f66ef6174b770c625be5319eead1a63ca479e98f1a256890ff10be99c0e7f8cd0ffe16636e52b63d5c8bfd7a8f57adde
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5793: Attribute-based access policy cannot be deleted if it is applied to any channels
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one policy in existence on the server and applied to a channel:\
+1\. As system admin, go to Attribute-Based Access page in System Console and click the three-dot menu on the right of a policy that is applied to a channel\
+2\. Observe Delete is disabled\
+3\. Click the three-dot menu on the right of a policy that is not applied to any channels\
+4\. Click Delete
+
+**Expected**
+
+\- Policy that is applied to a channel cannot be deleted\
+\- Policy that isn't applied to any channels can be delete

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5794.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5794.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "User is auto-added to channel when a qualifying attribute is added to their profile (auto-add true)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239259589
+key: MM-T5794
+created_on: "2025-05-22T04:15:38Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 35b67e348a81f7af4e68781328874c5112459c4ce260e90039fb41af226c9e7fb3fdaa29bc85550c4c0795e606becc57
+steps_hashed: e64cb0d6e595664815bddd7c876a5aaf4de0c42d24238efb9b9e89c6b44c0979d89fedd8618eb5ac57ec030c73d6b0b1
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5794: User is auto-added to channel when a qualifying attribute is added to their profile (auto-add true)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one access policy in existence on the server, set to auto-add, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. As a user not in the channel and not having the required attribute\
+3\. Click user's own profile picture top right and select Profile\
+4\. Scroll down to the required custom attribute, click Edit, and add the required value\
+5\. Save the changes
+
+**Expected**
+
+\- User who now satisfies the policy is auto-added to the channel\
+\- \`User added\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5795.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5795.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "User can be added to channel by system admin after a qualifying attribute is added to their profile (auto-add false)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239261859
+key: MM-T5795
+created_on: "2025-05-22T04:53:34Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 9a2b8caf321da67ea242da7200c59a17c913c250a0a1362e6bde8271146ecfbe5832d2a6c34c91172c63b8342154234d
+steps_hashed: 538376354bc74c1f3603d4028cd22dd641c1d3e0df443f1c060b72a3163262c137c82eebea9623c367bc61365124fff4
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5795: User can be added to channel by system admin after a qualifying attribute is added to their profile (auto-add false)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one access policy in existence on the server, with auto-add set to false, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. As a user not in the channel and not having the required attribute\
+3\. Click user's own profile picture top right and select Profile\
+4\. Scroll down to the required custom attribute, click Edit, and add the required value\
+5\. Save the changes\
+6\. As system admin go to the channel and add the user to the channel
+
+**Expected**
+
+\- User who now satisfies the policy can be added to the channel by the admin\
+\- \`User added\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5796.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5796.md
@@ -1,0 +1,78 @@
+---
+# (Required) Ensure all values are filled up
+name: "User is auto-removed from channel when required attribute is removed from their user profile (auto-add true and auto-add false)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239262026
+key: MM-T5796
+created_on: "2025-05-22T04:56:15Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 5d13f2691068e924e8d1a9acf73bbfe396e85107e46863229c3e87f105e5d0aa486f4146450d9a0940dd4531f7c3b4ac
+steps_hashed: 9987a79a4da885e9f5863304adea4e7baf6b8b8a05d769dc8bedeb203c41e876aa77c1e468aecedb32b4dbd9c5be14cd
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5796: User is auto-removed from channel when required attribute is removed from their user profile (auto-add true and auto-add false)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+With at least one access policy in existence on the server, with auto-add set to false, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. As a user who is in the channel and has the required attribute\
+3\. Click user's own profile picture top right and select Profile\
+4\. Scroll down to the required custom attribute, click Edit, and remove or change the required value\
+5\. Save the changes
+
+**Expected**
+
+\- User who no longer satisfies the policy is auto-removed from the channel\
+\- \`User removed\` message is posted in the channel by System
+
+---
+
+**Step 2**
+
+With at least one access policy in existence on the server, with auto-add set to true, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. As a user who is in the channel and has the required attribute\
+3\. Click user's own profile picture top right and select Profile\
+4\. Scroll down to the required custom attribute, click Edit, and remove or change the required value\
+5\. Save the changes
+
+**Expected**
+
+\- User who no longer satisfies the policy is auto-removed from the channel\
+\- \`User removed\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5797.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5797.md
@@ -1,0 +1,75 @@
+---
+# (Required) Ensure all values are filled up
+name: "LDAP sync: User is auto-added to channel when qualifying attribute syncs to their profile (auto-add true)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239265312
+key: MM-T5797
+created_on: "2025-05-22T05:43:35Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: d77117ec7e83062c92c082f52ead6a51dd589bd18a435d1c1ee327f81df3b13a2e89c166a8e1333faebf85e2c549f6ae
+steps_hashed: e0567084204505a013976f2c0b12390abd38db38d21c8fb4416374e4685ef2231baa23cab41e05b63a9f883e5f1ae063
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5797: LDAP sync: User is auto-added to channel when qualifying attribute syncs to their profile (auto-add true)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+Ensure a policy exists on the server, with one attribute, set to auto-add, syncing with LDAP, using \`= is\`, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. Note an LDAP user not in the channel and not having the required attribute\
+3\. On the LDAP server, add the required attribute to the user's profile\
+4\. Back in Mattermost, sync LDAP
+
+**Expected**
+
+\- User who now satisfies the policy is auto-added to the channel\
+\- \`User added\` message is posted in the channel by System
+
+---
+
+**Step 2**
+
+Repeat above but use a policy that has two required attributes, one set to use \`ƒ contains\`\
+1\. Note an LDAP user who already has one of the required attributes but doesn't have the attribute that uses \`ƒ contains\`\
+2\. On the LDAP server, add second required value to satisfy \`ƒ contains\`\
+3\. In Mattermost, sync LDAP
+
+**Expected**
+
+\- User who now satisfies the policy is auto-added to the channel\
+\- \`User added\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5798.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5798.md
@@ -1,0 +1,77 @@
+---
+# (Required) Ensure all values are filled up
+name: "LDAP sync: User can be added to channel by admin after editing qualifying attribute and syncing to their profile (auto-add false)"
+status: Draft
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239265667
+key: MM-T5798
+created_on: "2025-05-22T05:53:24Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 4fbf9aa96ced7927534a069aac2c3d33d66e98b115bc7256f4073c5ea1f789e5e8e86a99b5f689cab58a557e51c66802
+steps_hashed: 1d4fd30696655d75f3f9bb1c6ee287c856d0d9ba729240f5c0f962d3fe43fd73c71f1edb86d6f4423f71050810f61e4d
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5798: LDAP sync: User can be added to channel by admin after editing qualifying attribute and syncing to their profile (auto-add false)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+Ensure a policy exists on the server, with one attribute, with auto-add false, syncing with LDAP, using \`= is\`, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. Note an LDAP user not in the channel who has the attribute but a different value than is required\
+3\. On the LDAP server, change the attribute on the user's profile to have the required value\
+4\. Back in Mattermost, sync LDAP\
+5\. Still as admin, go to channel and add the user
+
+**Expected**
+
+\- User who now satisfies the policy is added to the channel by the admin\
+\- \`User added\` message is posted in the channel by System
+
+---
+
+**Step 2**
+
+Repeat above but use a policy that has an attribute set to use \`∈ in\`\
+1\. Note an LDAP user who already has the required attribute but doesn't have a value that satisfies \`∈ in\`\
+2\. On the LDAP server, change value to satisfy \`∈ in\`\
+3\. In Mattermost, sync LDAP\
+4\. Still as admin, go to channel and add the user
+
+**Expected**
+
+\- User who now satisfies the policy is added to the channel by admin\
+\- \`User added\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5799.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5799.md
@@ -1,0 +1,75 @@
+---
+# (Required) Ensure all values are filled up
+name: "LDAP sync: User is removed from channel after required attribute is removed from their LDAP account and synced (auto-add true or auto-add false)"
+status: Active
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239266559
+key: MM-T5799
+created_on: "2025-05-22T06:01:16Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: 41a45299c555c12f6c4dde28dd54f6160425d72f75b0af01baca8859076b7b2bc61cf894c481cba991aecc9ab062e4e5
+steps_hashed: aa8d19cf434e437070cde2c654bb0a9f2f220aaa66c8f6ffcfc97be77a5923f5c0c8e6e1a2a1620d503ecc98c4cb57b2
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5799: LDAP sync: User is removed from channel after required attribute is removed from their LDAP account and synced (auto-add true or auto-add false)
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+Ensure a policy exists on the server, with one attribute, set to auto-add, syncing with LDAP, using \`ƒ starts with\`, and applied to a channel:\
+1\. As system admin make a note of the attribute needed for a user to be auto-added to a channel\
+2\. Note an LDAP user already in the channel who has the required attribute\
+3\. On the LDAP server, remove the required attribute from the user's profile\
+4\. Back in Mattermost, sync LDAP
+
+**Expected**
+
+\- User who no longer satisfies the policy is removed from the channel\
+\- \`User removed\` message is posted in the channel by System
+
+---
+
+**Step 2**
+
+Repeat above but use a policy that has two required attributes, both using \`= is\`\
+1\. Note an LDAP user who already has both of the required attributes and is in the channel\
+2\. On the LDAP server, remove one of the required attributes\
+3\. In Mattermost, sync LDAP
+
+**Expected**
+
+\- User who no longer satisfies the policy is removed from the channel\
+\- \`User removed\` message is posted in the channel by System

--- a/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5800.md
+++ b/data/test-cases/channels/abac-attribute-based-access/abac-system-admin/MM-T5800.md
@@ -1,0 +1,81 @@
+---
+# (Required) Ensure all values are filled up
+name: "LDAP sync does not change the value of an attribute or its effect if a non-LDAP user had a value for it before it was set to sync with LDAP"
+status: Active
+priority: Normal
+folder: ABAC System Admin
+authors: "lindalumitchell"
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels:
+- abac
+- info-control
+- enterprise-advanced
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: 239357619
+key: MM-T5800
+created_on: "2025-05-23T03:50:37Z"
+last_updated: "2025-04-16T12:44:27Z"
+case_hashed: d0d0ef4f69cf3718cca5a74c72ee802058855a48265cbaf1dd4e8dc939e6f78cc6eef899050d2d2f2b94202df06bef51
+steps_hashed: 982c10a4f8a8b1c8020ffbe645e81f71941a3e6ab0509f56d657de706c95769bceb8abe277bfb67039c1408c1fab7d3a
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5800: LDAP sync does not change the value of an attribute or its effect if a non-LDAP user had a value for it before it was set to sync with LDAP
+
+**Precondition**
+
+\- Enterprise advanced (formerly known as Premium) license\
+\- --env MM\_FEATUREFLAGS\_CustomProfileAttributes=true,MM\_FEATUREFLAGS\_AttributeBasedAccessControl=true\
+\- Custom profile attributes have been created in System Console > System ​Attributes (Properties), so that they can be used to create a policy
+
+---
+
+**Step 1**
+
+1\. Create custom profile attribute called \`Hello\` and do not add it to an ABAC policy or sync it with LDAP yet\
+2\. As a non-LDAP user (email/password e.g.), set a value \`no\` for attribute \`Hello\` in your profile\
+3\. As system admin, in System Console create a new policy with \`Hello\` attribute and value \`yes\`, auto-add true, and set the attribute to sync with LDAP. Map the \`Hello\` attribute to the \`description\` field on the LDAP server\
+3\. On the LDAP server add value \`yes\` to the mapped attribute \`description\` on a third user's profile who logs in using LDAP\
+4\. Back in Mattermost, have the LDAP user log in\
+5\. As system admin, sync LDAP\
+6\. Verify in the LDAP user's profile that they received the \`Hello\` \`yes\` value synced over from LDAP\
+7\. As system admin, sync attribute-based access\
+8\. As the LDAP user verify you are added to the channel that is linked to the policy\
+9\. As the non-LDAP user verify you still have \`Hello\` set to \`no\` in your profile and cannot edit it (and have not been added to the linked channel)\
+10\. As system admin change the policy to \`Hello\` =is \`no\` and sync attribute-based access
+
+**Expected**
+
+\- Non-LDAP user who now satisfies the policy is auto-added to the channel based on the value they had before the attribute was added to a policy\
+\- LDAP user who no longer satisfies the policy is removed from the channel
+
+---
+
+**Step 2**
+
+Repeat above but use a policy that has two required attributes, one set to use \`ƒ contains\`\
+1\. Note an LDAP user who already has one of the required attributes but doesn't have the attribute that uses \`ƒ contains\`\
+2\. On the LDAP server, add second required value to satisfy \`ƒ contains\`\
+3\. In Mattermost, sync LDAP
+
+**Expected**
+
+\- User who now satisfies the policy is auto-added to the channel\
+\- \`User added\` message is posted in the channel by System


### PR DESCRIPTION
This was my first round of ABAC test cases, which I wrote directly in Zephyr and am syncing over to the repo.

- Added 19 new test cases for ABAC system admin functionality (MM-T5782 to MM-T5800)
- Tests cover first iteration, with system console controls and system admin access
- Synced from Zephyr test management
