### PR TITLE
Added the test cases for the Zoom meeting in threads and create new meeting option

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2133,7 +2133,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6335,7 +6335,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5801,7 +5801,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/data/test-cases/plugins/zoom/general/Create_new_meeting.md
+++ b/data/test-cases/plugins/zoom/general/Create_new_meeting.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "Click on `Create new meeting` option when a meeting was already created."
+status: Active
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Connect the Zoom account to your MM account.
+2. Create a Zoom meeting by running the slash command `/zoom start <meeting topic>` in any desired channel or DM/GM on MM.
+3. Again run the slash command `/zoom start <meeting topic>` in the desired channel or DM/GM on MM.
+4. Click on the `Create new meeting` option in the slack attachment for Zoom meeting in the desired channel or DM/GM on MM.
+
+**Expected**
+
+The user should get redirected to the new Zoom meeting or should get a slack attachment if the Zoom meeting setting is set to `Ask` for selecting the meeting ID in the desired channel or DM/GM on MM.
+
+**Step 2**
+
+1. Connect the Zoom account to your MM account.
+2. Create a Zoom meeting by clicking on the Zoom icon in the app bar/channel header in any desired channel or DM/GM on MM.
+3. Navigate to the desired thread and again click on the Zoom icon in the app bar/channel header in the desired channel or DM/GM on MM.
+4. Click on the `Create new meeting` option in the slack attachment for Zoom meeting in the desired channel or DM/GM on MM.
+
+**Expected**
+
+The user should get redirected to the new Zoom meeting or should get a slack attachment if the Zoom setting is set to `Ask` for selecting the meeting ID in the desired channel or DM/GM on MM.
+
+**Step 3**
+
+1. After step 2, again navigate to the desired channel or DM/GM on MM without ending the meeting on Zoom and click on the `Create new meeting` option on the existing slack attachment for Zoom meeting.
+
+**Expected**
+
+The user should get redirected to the new Zoom meeting or should get a slack attachment if the Zoom setting is set to `Ask` for selecting the meeting ID in the desired channel or DM/GM on MM.

--- a/data/test-cases/plugins/zoom/general/Meeting_in_threads.md
+++ b/data/test-cases/plugins/zoom/general/Meeting_in_threads.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "Create a Zoom meeting in the threads on MM."
+status: Active
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Connect the Zoom account to you MM account.
+2. Enable the Collapsed Reply Threads(CRT) in the system console on MM and open the `threads` from the LHS on MM.
+3. Select any desried thread from the list of `followed threads` and run the slash command `/zoom start <meeting topic>` in the thread on MM.
+
+**Expected**
+
+The slack attachment for new Zoom meeting should get generated in the desired thread on MM.
+
+**Step 2**
+
+1. Connect the Zoom account to your MM account.
+2. Enable the `Collapsed Reply Threads(CRT)` in the system console on MM and open the `threads` from the LHS on MM.
+3. Select any desired thread from the list of `followed threads` and click on the Zoom icon in the app bar on MM.
+
+**Expected**
+
+The slack attachment for new Zoom meeting should get generated in the desired thread on MM.
+
+**Step 3**
+
+1. Connect the Zoom account to your MM account.
+2. Enable the Collapsed Reply Threads(CRT) in the system console on MM and open the `threads` from the LHS on MM.
+3. Select any desired thread from the list of `followed threads` in which a meeting is already created and create a new meeting with either slash command `/zoom start <meeting topic>` or by clicking the Zoom icon in the app bar on MM.
+
+**Expected**
+
+The slack attachment for Zoom meeting to `Create new meeting` or `Join existing meeting` should get generated in the desired thread on MM. 

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
#### Summary

This PR consists the test cases for the following scenarios,

- Creating a Zoom meeting in the thread using slash command. 
- Creating a Zoom meeting in the thread using Zoom icon in the app bar. 
- Clicking on the Create new meeting option when there is already a meeting created and not ended.
