### PR TITLE
feat: test cases for Google Calendar plugin

### DIFF
--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5961.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5961.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin opens event creation from channel menu"
+status: Draft
+priority: High
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5961
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5961: Plugin opens event creation from channel menu
+
+---
+
+**Objective**
+
+Verify the Create calendar event flow can be launched from the channel menu.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled and user is connected.
+
+---
+
+**Step 1**
+
+1. Open any channel.
+2. Open the channel menu.
+3. Select Create calendar event.
+
+**Expected**
+
+Event creation modal opens and required fields are visible.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5961.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5961.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin opens event creation from channel menu"
-status: Draft
+status: Active
 priority: High
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5962.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5962.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin creates an event from channel menu with required fields"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5962
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5962: Plugin creates an event from channel menu with required fields
+
+---
+
+**Objective**
+
+Verify a calendar event can be created using only required fields.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled and user is connected.
+
+---
+
+**Step 1**
+
+1. Open Create calendar event from the channel menu.
+2. Enter title, date, start time, and end time.
+3. Click Create.
+
+**Expected**
+
+Event is created successfully and the user receives confirmation in Mattermost.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5962.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5962.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin creates an event from channel menu with required fields"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5963.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5963.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin creates an event with channel reminder destination"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5963
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5963: Plugin creates an event with channel reminder destination
+
+---
+
+**Objective**
+
+Verify event creation supports selecting a channel for reminder posts.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled and user is connected.
+
+---
+
+**Step 1**
+
+1. Open Create calendar event.
+2. Fill required event fields.
+3. Select a channel for event reminders.
+4. Click Create.
+
+**Expected**
+
+Event is created and reminder destination channel is saved.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5963.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5963.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin creates an event with channel reminder destination"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5964.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5964.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin sends direct message reminder before event start"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5964
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5964: Plugin sends direct message reminder before event start
+
+---
+
+**Objective**
+
+Verify user receives DM reminder approximately 5 minutes before event start.
+
+---
+
+**Precondition**
+
+User is connected, reminders are enabled, and user has an upcoming event in less than 10 minutes.
+
+---
+
+**Step 1**
+
+1. Ensure reminders are enabled in plugin settings.
+2. Create or use an event that starts within 10 minutes.
+3. Wait for reminder window.
+
+**Expected**
+
+User receives a direct message reminder before the meeting starts.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5964.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5964.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin sends direct message reminder before event start"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5965.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5965.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin posts channel reminder for channel-linked event"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5965
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5965: Plugin posts channel reminder for channel-linked event
+
+---
+
+**Objective**
+
+Verify reminder is posted to the selected channel before meeting start.
+
+---
+
+**Precondition**
+
+User is connected and has an event linked to a Mattermost channel.
+
+---
+
+**Step 1**
+
+1. Create an event and set a channel reminder destination.
+2. Wait until reminder window before event starts.
+3. Observe the selected channel.
+
+**Expected**
+
+Reminder message is posted in the selected channel with event details.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5965.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5965.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin posts channel reminder for channel-linked event"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5966.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5966.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin automatically sets Away during meeting and reverts after event"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5966
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5966: Plugin automatically sets Away during meeting and reverts after event
+
+---
+
+**Objective**
+
+Verify user status changes to Away during event and reverts after event ends.
+
+---
+
+**Precondition**
+
+User is connected and status auto-update is enabled with Away option.
+
+---
+
+**Step 1**
+
+1. Configure automatic status update to Away.
+2. Create or use an event starting within 10 minutes.
+3. Observe user status during event start and after event end.
+
+**Expected**
+
+Status changes to Away during the event and returns to previous/online status after the event.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5966.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5966.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin automatically sets Away during meeting and reverts after event"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5967.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5967.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin automatically sets Do Not Disturb during meeting and reverts after event"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5967
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5967: Plugin automatically sets Do Not Disturb during meeting and reverts after event
+
+---
+
+**Objective**
+
+Verify user status changes to Do Not Disturb during event and reverts after event ends.
+
+---
+
+**Precondition**
+
+User is connected and status auto-update is enabled with Do Not Disturb option.
+
+---
+
+**Step 1**
+
+1. Configure automatic status update to Do Not Disturb.
+2. Create or use an event starting within 10 minutes.
+3. Observe status at event start and after event end.
+
+**Expected**
+
+Status changes to Do Not Disturb during the event and returns after the event ends.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5967.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5967.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin automatically sets Do Not Disturb during meeting and reverts after event"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5968.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5968.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin prompts for confirmation when confirmation mode is enabled"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5968
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5968: Plugin prompts for confirmation when confirmation mode is enabled
+
+---
+
+**Objective**
+
+Verify plugin asks for confirmation before applying status changes.
+
+---
+
+**Precondition**
+
+User is connected and Get Confirmation setting is enabled.
+
+---
+
+**Step 1**
+
+1. Enable Get Confirmation in plugin settings.
+2. Use an event that starts within 10 minutes.
+3. Observe reminder interaction before status change.
+
+**Expected**
+
+Plugin prompts for confirmation and applies status change only after user confirmation.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5968.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5968.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin prompts for confirmation when confirmation mode is enabled"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5969.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5969.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin sends daily summary at configured time when enabled"
-status: Draft
+status: Active
 priority: Normal
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5969.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5969.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin sends daily summary at configured time when enabled"
+status: Draft
+priority: Normal
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5969
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5969: Plugin sends daily summary at configured time when enabled
+
+---
+
+**Objective**
+
+Verify daily summary is delivered according to user settings.
+
+---
+
+**Precondition**
+
+User is connected, daily summary is enabled, and summary time is configured.
+
+---
+
+**Step 1**
+
+1. Enable daily summary and set summary time.
+2. Ensure there is at least one event in the summary period.
+3. Wait until configured summary time.
+
+**Expected**
+
+User receives a daily summary message at the configured time.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5970.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5970.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Plugin does not send reminders when reminders are disabled"
+status: Draft
+priority: Low
+folder: Events and Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P4 - Low-Impact (Edge or unsuitable to repeat?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5970
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5970: Plugin does not send reminders when reminders are disabled
+
+---
+
+**Objective**
+
+Verify disabling reminders suppresses pre-event DM reminders.
+
+---
+
+**Precondition**
+
+User is connected and has an upcoming event.
+
+---
+
+**Step 1**
+
+1. Disable reminders in plugin settings.
+2. Use an event that starts within 10 minutes.
+3. Wait through reminder window.
+
+**Expected**
+
+No pre-event direct message reminder is sent while reminders are disabled.

--- a/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5970.md
+++ b/data/test-cases/plugins/google-calendar/events-and-notifications/MM-T5970.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "Plugin does not send reminders when reminders are disabled"
-status: Draft
+status: Active
 priority: Low
 folder: Events and Notifications
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5947.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5947.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal help displays command help"
-status: Draft
+status: Active
 priority: High
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5947.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5947.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal help displays command help"
+status: Draft
+priority: High
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5947
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5947: /gcal help displays command help
+
+---
+
+**Objective**
+
+Verify /gcal help returns available user-facing commands.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /gcal help.
+2. Review listed commands and usage hints.
+
+**Expected**
+
+Help text is displayed and includes current user-facing gcal commands.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5948.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5948.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal info displays plugin information"
+status: Draft
+priority: High
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5948
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5948: /gcal info displays plugin information
+
+---
+
+**Objective**
+
+Verify /gcal info returns plugin metadata and version information.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /gcal info.
+2. Review returned plugin information.
+
+**Expected**
+
+Plugin info is displayed (including version/build details where available).

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5948.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5948.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal info displays plugin information"
-status: Draft
+status: Active
 priority: High
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5949.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5949.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal connect connects a user account"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5949
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5949: /gcal connect connects a user account
+
+---
+
+**Objective**
+
+Verify a user can connect Mattermost to Google Calendar using the slash command.
+
+---
+
+**Precondition**
+
+Google Calendar plugin is enabled and configured with valid OAuth Client ID and Client Secret.
+
+---
+
+**Step 1**
+
+1. Ensure you are not currently connected to Google Calendar.
+2. Run /gcal connect in any channel.
+3. Open the OAuth link from the bot response.
+4. Complete consent in Google.
+
+**Expected**
+
+Connection flow opens and completes successfully. The bot confirms the account is connected.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5949.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5949.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal connect connects a user account"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5950.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5950.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal disconnect disconnects a connected user"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5950.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5950.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal disconnect disconnects a connected user"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5950
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5950: /gcal disconnect disconnects a connected user
+
+---
+
+**Objective**
+
+Verify a connected user can disconnect via slash command.
+
+---
+
+**Precondition**
+
+User is already connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal disconnect in any channel.
+2. Confirm disconnect if prompted.
+
+**Expected**
+
+User is disconnected. Running a command requiring connection shows guidance to reconnect.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5951.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5951.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal settings opens personal plugin settings"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5951
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5951: /gcal settings opens personal plugin settings
+
+---
+
+**Objective**
+
+Verify users can open and edit personal Google Calendar plugin settings from slash command.
+
+---
+
+**Precondition**
+
+User is connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal settings.
+2. In the settings panel, change one setting (for example reminders or status update preference).
+3. Save the change.
+4. Run /gcal settings again.
+
+**Expected**
+
+Settings panel opens and saved values persist on re-open.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5951.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5951.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal settings opens personal plugin settings"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5952.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5952.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal today shows today's events"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5952
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5952: /gcal today shows today's events
+
+---
+
+**Objective**
+
+Verify today's agenda is returned with /gcal today.
+
+---
+
+**Precondition**
+
+User is connected and has at least one event today in Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal today.
+2. Review the bot response.
+
+**Expected**
+
+Response includes today's events with correct time details for the user timezone.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5952.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5952.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal today shows today's events"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5953.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5953.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal tomorrow shows tomorrow's events"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5953
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5953: /gcal tomorrow shows tomorrow's events
+
+---
+
+**Objective**
+
+Verify tomorrow's agenda is returned with /gcal tomorrow.
+
+---
+
+**Precondition**
+
+User is connected and has at least one event tomorrow in Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal tomorrow.
+2. Review the bot response.
+
+**Expected**
+
+Response includes tomorrow's events with correct time details for the user timezone.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5953.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5953.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal tomorrow shows tomorrow's events"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5954.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5954.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal viewcal shows a 14-day agenda"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5954.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5954.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal viewcal shows a 14-day agenda"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5954
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5954: /gcal viewcal shows a 14-day agenda
+
+---
+
+**Objective**
+
+Verify /gcal viewcal shows upcoming events in the expected date range.
+
+---
+
+**Precondition**
+
+User is connected and has upcoming events in the next 14 days.
+
+---
+
+**Step 1**
+
+1. Run /gcal viewcal.
+2. Review the bot response for date range and event content.
+
+**Expected**
+
+Response includes upcoming events for the next 14 days including today.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5955.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5955.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal event create creates an event when connected"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5955
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5955: /gcal event create creates an event when connected
+
+---
+
+**Objective**
+
+Verify a connected user can create a calendar event using /gcal event create.
+
+---
+
+**Precondition**
+
+User is connected to Google Calendar and is in a channel where slash commands are enabled.
+
+---
+
+**Step 1**
+
+1. Run /gcal event create.
+2. Fill required fields for title, date, start time, and end time.
+3. Submit the form.
+
+**Expected**
+
+Event is created successfully and confirmation is shown in Mattermost.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5955.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5955.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal event create creates an event when connected"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5956.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5956.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal event create prompts connection when user is not connected"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5956.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5956.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal event create prompts connection when user is not connected"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5956
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5956: /gcal event create prompts connection when user is not connected
+
+---
+
+**Objective**
+
+Verify /gcal event create returns reconnect guidance for non-connected users.
+
+---
+
+**Precondition**
+
+User is not connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Ensure user is disconnected.
+2. Run /gcal event create.
+
+**Expected**
+
+An ephemeral message indicates the account is not connected and suggests /gcal connect.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5957.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5957.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal summary view shows daily summary"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5957
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5957: /gcal summary view shows daily summary
+
+---
+
+**Objective**
+
+Verify /gcal summary view displays the current daily summary output.
+
+---
+
+**Precondition**
+
+User is connected and has daily summary configured.
+
+---
+
+**Step 1**
+
+1. Run /gcal summary view.
+2. Review summary content.
+
+**Expected**
+
+Daily summary is displayed and reflects current summary settings.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5957.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5957.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal summary view shows daily summary"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5958.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5958.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal summary settings shows summary configuration"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5958
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5958: /gcal summary settings shows summary configuration
+
+---
+
+**Objective**
+
+Verify /gcal summary settings displays current summary preferences.
+
+---
+
+**Precondition**
+
+User is connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal summary settings.
+2. Review returned summary options and values.
+
+**Expected**
+
+Current daily summary configuration is shown correctly.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5958.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5958.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal summary settings shows summary configuration"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5959.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5959.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal summary time updates delivery time"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5959.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5959.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal summary time updates delivery time"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5959
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5959: /gcal summary time updates delivery time
+
+---
+
+**Objective**
+
+Verify users can set daily summary delivery time via slash command.
+
+---
+
+**Precondition**
+
+User is connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal summary time 09:00.
+2. Run /gcal summary settings.
+3. Verify the configured time.
+
+**Expected**
+
+The daily summary time is updated and shown in summary settings.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5960.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5960.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/gcal summary enable and disable toggles daily summary"
+status: Draft
+priority: Normal
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5960
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5960: /gcal summary enable and disable toggles daily summary
+
+---
+
+**Objective**
+
+Verify users can enable and disable daily summary via slash commands.
+
+---
+
+**Precondition**
+
+User is connected to Google Calendar.
+
+---
+
+**Step 1**
+
+1. Run /gcal summary disable.
+2. Run /gcal summary settings and verify summary is disabled.
+3. Run /gcal summary enable.
+4. Run /gcal summary settings and verify summary is enabled.
+
+**Expected**
+
+Enable and disable commands update summary state correctly.

--- a/data/test-cases/plugins/google-calendar/slash-commands/MM-T5960.md
+++ b/data/test-cases/plugins/google-calendar/slash-commands/MM-T5960.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: "/gcal summary enable and disable toggles daily summary"
-status: Draft
+status: Active
 priority: Normal
 folder: Slash Commands
 authors: "@ogi-m"


### PR DESCRIPTION
 Summary
- Add 24 Google Calendar plugin test cases under `data/test-cases/plugins/google-calendar`
- Covers `/gcal` slash command flows and non-command flows (event creation, reminders, and status sync)
- Test cases were first added into Zephyr, so Zephyr-assigned keys (`MM-T5947` through `MM-T5970`) are included