### PR TITLE
feat: add Google Drive plugin test cases

### DIFF
--- a/data/test-cases/plugins/google-drive/comments-and-replies/MM-T5990.md
+++ b/data/test-cases/plugins/google-drive/comments-and-replies/MM-T5990.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Comment activity notification includes Reply to comment action"
+status: Active
+priority: Normal
+folder: Comments and Replies
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5990
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5990: Comment activity notification includes Reply to comment action
+
+---
+
+**Objective**
+
+Verify comment activity DM contains contextual details and reply action.
+
+---
+
+**Precondition**
+
+User is connected, notifications are enabled, and Google Drive comment activity occurs on a tracked file.
+
+---
+
+**Step 1**
+
+1. Enable /google-drive notifications start.
+2. Trigger a new comment on a tracked Google Drive file.
+3. Check bot DM in Mattermost.
+
+**Expected**
+
+Bot DM includes comment context and a Reply to comment button for direct interaction.

--- a/data/test-cases/plugins/google-drive/comments-and-replies/MM-T5991.md
+++ b/data/test-cases/plugins/google-drive/comments-and-replies/MM-T5991.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Reply to comment flow posts confirmation in thread"
+status: Active
+priority: Normal
+folder: Comments and Replies
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5991
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5991: Reply to comment flow posts confirmation in thread
+
+---
+
+**Objective**
+
+Verify reply dialog submission creates reply and posts confirmation in Mattermost thread.
+
+---
+
+**Precondition**
+
+User has a comment activity notification with Reply to comment action.
+
+---
+
+**Step 1**
+
+1. Click Reply to comment on a Google Drive notification attachment.
+2. Enter reply text and submit dialog.
+3. Review resulting Mattermost thread/post.
+
+**Expected**
+
+Reply is created in Google Drive and bot posts confirmation message with the submitted reply content.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5977.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5977.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc opens file creation dialog"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5977
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5977: /google-drive create doc opens file creation dialog
+
+---
+
+**Objective**
+
+Verify create doc command opens interactive dialog for creating a Google document.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Observe modal fields and options.
+
+**Expected**
+
+Create dialog opens with fields for Name, Message, File Access, and Share in this Channel.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5978.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5978.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create sheet opens file creation dialog"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5978
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5978: /google-drive create sheet opens file creation dialog
+
+---
+
+**Objective**
+
+Verify create sheet command opens interactive dialog for creating a Google spreadsheet.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create sheet.
+2. Observe modal title and fields.
+
+**Expected**
+
+Create dialog opens with Google Sheet context and file creation fields.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5979.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5979.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create slide opens file creation dialog"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5979
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5979: /google-drive create slide opens file creation dialog
+
+---
+
+**Objective**
+
+Verify create slide command opens interactive dialog for creating a Google presentation.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create slide.
+2. Observe modal title and fields.
+
+**Expected**
+
+Create dialog opens with Google Slide context and file creation fields.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5980.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5980.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create without file type returns usage guidance"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5980
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5980: /google-drive create without file type returns usage guidance
+
+---
+
+**Objective**
+
+Verify create command validates required file type argument.
+
+---
+
+**Precondition**
+
+Plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create with no additional arguments.
+
+**Expected**
+
+User gets instruction to specify doc, sheet, or slide and to use help for more information.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5981.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5981.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create with invalid file type returns validation error"
+status: Active
+priority: Low
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5981
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5981: /google-drive create with invalid file type returns validation error
+
+---
+
+**Objective**
+
+Verify create command rejects unknown file type values.
+
+---
+
+**Precondition**
+
+Plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create pdf.
+
+**Expected**
+
+User sees an error indicating the provided create option is not valid.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5993.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5993.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc with Keep file private keeps file restricted"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5993
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5993: /google-drive create doc with Keep file private keeps file restricted
+
+---
+
+**Objective**
+
+Verify selecting Keep file private creates the file without granting additional sharing access.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and can create documents.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Enter Name and optional Message.
+3. Select File Access as Keep file private.
+4. Submit the dialog.
+
+**Expected**
+
+File is created successfully and is not shared to channel members by default.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5994.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5994.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc with Members of the channel can comment grants channel member access"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5994
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5994: /google-drive create doc with Members of the channel can comment grants channel member access
+
+---
+
+**Objective**
+
+Verify selecting a Members of the channel access option shares with channel members using the selected permission.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and target channel has at least one other non-bot member.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Enter Name and optional Message.
+3. Select File Access as Members of the channel can comment.
+4. Submit the dialog.
+
+**Expected**
+
+File is created and channel members are granted comment access according to selected permission.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5995.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5995.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc with Anyone with the link can comment grants link-based access"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5995
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5995: /google-drive create doc with Anyone with the link can comment grants link-based access
+
+---
+
+**Objective**
+
+Verify selecting an Anyone with the link option creates a file with link-based access.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and domain sharing policy allows Anyone with the link permissions.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Enter Name and optional Message.
+3. Select File Access as Anyone with the link can comment.
+4. Submit the dialog.
+
+**Expected**
+
+File is created with link-based comment permission when policy allows.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5996.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5996.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc with Share in this Channel enabled posts file in channel"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5996
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5996: /google-drive create doc with Share in this Channel enabled posts file in channel
+
+---
+
+**Objective**
+
+Verify enabling Share in this Channel posts a file card/message into the current channel.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and can create documents in a channel.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Fill required fields.
+3. Enable Share in this Channel.
+4. Submit the dialog.
+
+**Expected**
+
+File is created and a message with the file attachment/link is posted in the current channel.

--- a/data/test-cases/plugins/google-drive/file-creation/MM-T5997.md
+++ b/data/test-cases/plugins/google-drive/file-creation/MM-T5997.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive create doc with Share in this Channel disabled does not post file in channel"
+status: Active
+priority: Normal
+folder: File Creation
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5997
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5997: /google-drive create doc with Share in this Channel disabled does not post file in channel
+
+---
+
+**Objective**
+
+Verify leaving Share in this Channel disabled does not post the file into the channel.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and can create documents in a channel.
+
+---
+
+**Step 1**
+
+1. Run /google-drive create doc.
+2. Fill required fields.
+3. Leave Share in this Channel disabled.
+4. Submit the dialog.
+
+**Expected**
+
+File is created successfully and no file post is published in the channel.

--- a/data/test-cases/plugins/google-drive/notifications/MM-T5982.md
+++ b/data/test-cases/plugins/google-drive/notifications/MM-T5982.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive notifications start enables activity notifications"
+status: Active
+priority: Normal
+folder: Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5982
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5982: /google-drive notifications start enables activity notifications
+
+---
+
+**Objective**
+
+Verify notifications start command enables Google Drive activity notifications.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and notifications are currently disabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive notifications start.
+
+**Expected**
+
+User receives confirmation that Google Drive activity notifications are enabled.

--- a/data/test-cases/plugins/google-drive/notifications/MM-T5983.md
+++ b/data/test-cases/plugins/google-drive/notifications/MM-T5983.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive notifications stop disables activity notifications"
+status: Active
+priority: Normal
+folder: Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5983
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5983: /google-drive notifications stop disables activity notifications
+
+---
+
+**Objective**
+
+Verify notifications stop command disables Google Drive activity notifications.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and notifications are currently enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive notifications stop.
+
+**Expected**
+
+User receives confirmation that Google Drive activity notifications are disabled.

--- a/data/test-cases/plugins/google-drive/notifications/MM-T5984.md
+++ b/data/test-cases/plugins/google-drive/notifications/MM-T5984.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive notifications with no subcommand returns usage error"
+status: Active
+priority: Low
+folder: Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5984
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5984: /google-drive notifications with no subcommand returns usage error
+
+---
+
+**Objective**
+
+Verify notifications command validates required subcommand.
+
+---
+
+**Precondition**
+
+Plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive notifications with no arguments.
+
+**Expected**
+
+User sees message asking to specify start or stop subcommand.

--- a/data/test-cases/plugins/google-drive/notifications/MM-T5985.md
+++ b/data/test-cases/plugins/google-drive/notifications/MM-T5985.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive notifications with invalid subcommand returns validation error"
+status: Active
+priority: Low
+folder: Notifications
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5985
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5985: /google-drive notifications with invalid subcommand returns validation error
+
+---
+
+**Objective**
+
+Verify notifications command rejects unknown subcommands.
+
+---
+
+**Precondition**
+
+Plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive notifications pause.
+
+**Expected**
+
+User sees an error indicating provided notifications subcommand is not valid.

--- a/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5986.md
+++ b/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5986.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Post menu Upload file to Google Drive uploads selected attachment"
+status: Active
+priority: Normal
+folder: Post Menu Upload
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5986
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5986: Post menu Upload file to Google Drive uploads selected attachment
+
+---
+
+**Objective**
+
+Verify single-file upload action from post menu uploads selected attachment to Drive.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and a post with one attachment exists.
+
+---
+
+**Step 1**
+
+1. Open post menu on a post with one or more attached files.
+2. Select Upload file to Google Drive.
+3. Choose a file in the modal and submit.
+
+**Expected**
+
+Upload completes and user receives success message that file was uploaded to Google Drive.

--- a/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5987.md
+++ b/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5987.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "Post menu Upload file to Google Drive action is unavailable for posts without attachments"
+status: Active
+priority: Low
+folder: Post Menu Upload
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5987
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5987: Post menu Upload file to Google Drive action is unavailable for posts without attachments
+
+---
+
+**Objective**
+
+Verify single-file upload action is not shown for posts with no attachments.
+
+---
+
+**Precondition**
+
+A post without file attachments exists.
+
+---
+
+**Step 1**
+
+1. Open post menu on a post with no attached files.
+
+**Expected**
+
+Upload file to Google Drive action is not shown in the post menu.

--- a/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5988.md
+++ b/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5988.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "Post menu Upload all files to Google Drive uploads all attachments"
+status: Active
+priority: Normal
+folder: Post Menu Upload
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5988
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5988: Post menu Upload all files to Google Drive uploads all attachments
+
+---
+
+**Objective**
+
+Verify upload-all action uploads every attachment from the selected post.
+
+---
+
+**Precondition**
+
+User is connected to Google Drive and a post with two or more attachments exists.
+
+---
+
+**Step 1**
+
+1. Open post menu on a post with at least two files.
+2. Select Upload all files to Google Drive.
+3. Confirm submission in the modal.
+
+**Expected**
+
+All attached files are uploaded and user receives success message for uploading all files.

--- a/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5989.md
+++ b/data/test-cases/plugins/google-drive/post-menu-upload/MM-T5989.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: "Post menu Upload all files to Google Drive action is unavailable when fewer than two attachments exist"
+status: Active
+priority: Low
+folder: Post Menu Upload
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5989
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5989: Post menu Upload all files to Google Drive action is unavailable when fewer than two attachments exist
+
+---
+
+**Objective**
+
+Verify upload-all action visibility is limited to posts with at least two attachments.
+
+---
+
+**Precondition**
+
+A post with zero or one attachment exists.
+
+---
+
+**Step 1**
+
+1. Open post menu on posts that have one file and no files.
+
+**Expected**
+
+Upload all files to Google Drive action is not shown for posts with fewer than two attachments.

--- a/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5972.md
+++ b/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5972.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive connect shows OAuth link for disconnected user"
+status: Active
+priority: High
+folder: Setup and Authentication
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5972
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5972: /google-drive connect shows OAuth link for disconnected user
+
+---
+
+**Objective**
+
+Verify /google-drive connect provides a valid OAuth connect link.
+
+---
+
+**Precondition**
+
+Google Drive plugin OAuth is configured and user is not connected.
+
+---
+
+**Step 1**
+
+1. Ensure current user has no Google token connected.
+2. Run /google-drive connect.
+3. Click the returned link.
+
+**Expected**
+
+Bot returns a link to the plugin OAuth connect endpoint and the Google authorization flow opens.

--- a/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5973.md
+++ b/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5973.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive setup starts setup wizard for system admin"
+status: Active
+priority: Normal
+folder: Setup and Authentication
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5973
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5973: /google-drive setup starts setup wizard for system admin
+
+---
+
+**Objective**
+
+Verify system admin can start the guided setup flow from slash command.
+
+---
+
+**Precondition**
+
+User is a system admin and plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Log in as system admin.
+2. Run /google-drive setup.
+3. Proceed through welcome step and open OAuth value dialog.
+
+**Expected**
+
+Setup flow starts in bot DM and OAuth configuration dialog is available.

--- a/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5974.md
+++ b/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5974.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive setup is blocked for non-system-admin user"
+status: Active
+priority: Normal
+folder: Setup and Authentication
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5974
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5974: /google-drive setup is blocked for non-system-admin user
+
+---
+
+**Objective**
+
+Verify setup command is restricted to system admins.
+
+---
+
+**Precondition**
+
+User is not a system admin and plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Log in as non-system-admin user.
+2. Run /google-drive setup.
+
+**Expected**
+
+User receives an error indicating only system admins are allowed to set up the plugin.

--- a/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5975.md
+++ b/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5975.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive disconnect removes an existing Google account connection"
+status: Active
+priority: Normal
+folder: Setup and Authentication
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5975
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5975: /google-drive disconnect removes an existing Google account connection
+
+---
+
+**Objective**
+
+Verify disconnect command clears the user connection.
+
+---
+
+**Precondition**
+
+User is already connected to Google Drive.
+
+---
+
+**Step 1**
+
+1. Run /google-drive disconnect.
+2. Run /google-drive connect after disconnect.
+
+**Expected**
+
+Disconnect confirmation is shown and connect command now offers OAuth link again.

--- a/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5976.md
+++ b/data/test-cases/plugins/google-drive/setup-and-authentication/MM-T5976.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive disconnect returns guidance when no account is connected"
+status: Active
+priority: Normal
+folder: Setup and Authentication
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5976
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5976: /google-drive disconnect returns guidance when no account is connected
+
+---
+
+**Objective**
+
+Verify disconnect command handles already-disconnected users gracefully.
+
+---
+
+**Precondition**
+
+User has no Google account connected.
+
+---
+
+**Step 1**
+
+1. Ensure user has no existing Google connection.
+2. Run /google-drive disconnect.
+
+**Expected**
+
+User sees message that no Google account is connected to Mattermost account.

--- a/data/test-cases/plugins/google-drive/slash-commands/MM-T5971.md
+++ b/data/test-cases/plugins/google-drive/slash-commands/MM-T5971.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive help displays command help"
+status: Active
+priority: High
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5971
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5971: /google-drive help displays command help
+
+---
+
+**Objective**
+
+Verify users can view supported slash commands using /google-drive help.
+
+---
+
+**Precondition**
+
+Google Drive plugin is enabled in Mattermost.
+
+---
+
+**Step 1**
+
+1. Run /google-drive help in any channel.
+2. Review the response from the Google Drive bot.
+
+**Expected**
+
+Help output lists available commands, including connect, disconnect, create, notifications, help, and about.

--- a/data/test-cases/plugins/google-drive/slash-commands/MM-T5992.md
+++ b/data/test-cases/plugins/google-drive/slash-commands/MM-T5992.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: "/google-drive about returns plugin build information"
+status: Active
+priority: Low
+folder: Slash Commands
+authors: "@ogi-m"
+team_ownership:
+- Core Features
+priority_p1_to_p4: P4 - Low-Impact (Edge or unsuitable to repeat?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T5992
+created_on: null
+last_updated: ""
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T5992: /google-drive about returns plugin build information
+
+---
+
+**Objective**
+
+Verify about command returns plugin metadata and version details.
+
+---
+
+**Precondition**
+
+Google Drive plugin is enabled.
+
+---
+
+**Step 1**
+
+1. Run /google-drive about.
+2. Review returned information.
+
+**Expected**
+
+Command returns plugin build information such as name, version, and manifest details.


### PR DESCRIPTION
<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary

- Adds 27 Active test cases for the newly supported Google Drive plugin under data/test-cases/plugins/google-drive
- Covers core user workflows: setup/authentication, slash commands, file creation, notifications, post-menu uploads, and comment/reply flows
- Includes Zephyr-assigned keys MM-T5971 through MM-T5997


#### Coverage
- /google-drive command flows: help, about, connect, disconnect, setup
- File creation modal behavior:
  - doc/sheet/slide flows
  - File Access variants (private, members, anyone with link)
  - Share in this Channel positive and negative scenarios
- Notifications start/stop and input validation
- Post menu upload actions (single/all files + visibility constraints)
- Comment activity notifications and reply flow

#### Is the feature in stable branch or under review?
- [x] Feature in stable branch (master, main)?
- [Google Drive plugin repo](https://github.com/mattermost/mattermost-plugin-google-drive)


#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
- [x] Browser
- [] Mobile App (version, OS)
- [x] Desktop App (version, OS)
