### PR TITLE
Feat: Add wrangler plugin test cases

### DIFF
--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6026.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6026.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Attach a standalone message to an existing thread'
-status: Draft
+status: Active
 priority: High
 folder: Attach Message
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6026.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6026.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Attach a standalone message to an existing thread'
+status: Draft
+priority: High
+folder: Attach Message
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6026
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6026: Attach a standalone message to an existing thread
+
+---
+
+**Objective**
+
+Verify that a standalone message can be attached to an existing thread
+using the slash command.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+A public channel exists with a thread (root message plus replies) and a
+separate standalone message (no replies and not part of any thread) in the
+same channel.
+
+---
+
+**Step 1**
+
+1. Note the standalone message ID and the root message ID of the target
+   thread.
+2. Run /wrangler attach message STANDALONE_MESSAGE_ID ROOT_MESSAGE_ID from
+   the channel containing both.
+3. Check the standalone message location.
+4. Open the target thread.
+
+**Expected**
+
+1. Both message IDs are noted.
+2. An ephemeral confirmation is returned: Message successfully attached to
+   thread.
+3. The original standalone message is deleted from the channel view.
+4. The message now appears as a reply in the target thread with the
+   original content and user attribution preserved.

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6027.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6027.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Attach message preserves file attachments'
-status: Draft
+status: Active
 priority: Normal
 folder: Attach Message
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6027.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6027.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Attach message preserves file attachments'
+status: Draft
+priority: Normal
+folder: Attach Message
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6027
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6027: Attach message preserves file attachments
+
+---
+
+**Objective**
+
+Verify that file attachments are preserved when a standalone message is
+attached to an existing thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+A public channel exists with a thread and a separate standalone message
+that has file attachments.
+
+---
+
+**Step 1**
+
+1. Post a standalone message with a file attachment in the channel.
+2. Run /wrangler attach message STANDALONE_MESSAGE_ID ROOT_MESSAGE_ID.
+3. Open the target thread and locate the attached message.
+4. Click on the file attachment.
+
+**Expected**
+
+1. The message with attachment is posted.
+2. The attach completes successfully.
+3. The attached message in the thread shows the same file attachment(s).
+4. The file downloads successfully and the content matches the original
+   file.

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6028.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6028.md
@@ -1,0 +1,69 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Attach message preserves reactions'
+status: Draft
+priority: Normal
+folder: Attach Message
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6028
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6028: Attach message preserves reactions
+
+---
+
+**Objective**
+
+Verify that emoji reactions are preserved when a standalone message is
+attached to an existing thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+A public channel exists with a thread and a separate standalone message
+that has emoji reactions.
+
+---
+
+**Step 1**
+
+1. Locate a standalone message with emoji reactions and note which
+   reactions are present.
+2. Run /wrangler attach message STANDALONE_MESSAGE_ID ROOT_MESSAGE_ID.
+3. Open the target thread and locate the attached message.
+
+**Expected**
+
+1. Reactions are noted.
+2. The attach completes successfully.
+3. The attached message in the thread has the same emoji reactions from the
+   same users as the original standalone message.

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6028.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6028.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Attach message preserves reactions'
-status: Draft
+status: Active
 priority: Normal
 folder: Attach Message
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6029.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6029.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Attach message sends DM to original author when executor differs'
+status: Draft
+priority: Normal
+folder: Attach Message
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6029
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6029: Attach message sends DM to original author when executor differs
+
+---
+
+**Objective**
+
+Verify that the original message author receives a DM from the Wrangler bot
+when a different user attaches their message to a thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and both users are authorized.
+A public channel contains a thread and a standalone message posted by User
+A.
+User B is a different user who is a member of the channel.
+
+---
+
+**Step 1**
+
+1. As User A post a standalone message in the channel.
+2. As User B run /wrangler attach message STANDALONE_MESSAGE_ID
+   ROOT_MESSAGE_ID.
+3. As User A check direct messages from the Wrangler bot.
+
+**Expected**
+
+1. Message is posted by User A.
+2. The attach completes successfully.
+3. User A receives a DM from the Wrangler bot containing a notification
+   about the attached message and a link to the thread.

--- a/data/test-cases/plugins/wrangler/attach-message/MM-T6029.md
+++ b/data/test-cases/plugins/wrangler/attach-message/MM-T6029.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Attach message sends DM to original author when executor differs'
-status: Draft
+status: Active
 priority: Normal
 folder: Attach Message
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6020.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6020.md
@@ -1,0 +1,76 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy a single message to another channel'
+status: Draft
+priority: High
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6020
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6020: Copy a single message to another channel
+
+---
+
+**Objective**
+
+Verify that a single message can be copied to another channel while the
+original remains in place.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist (source and target) and the user is a member of
+both.
+A standalone message exists in the source channel.
+
+---
+
+**Step 1**
+
+1. In the source channel run /wrangler list messages to obtain the message
+   ID.
+2. Run /wrangler list channels to obtain the target channel ID.
+3. Run /wrangler copy thread MESSAGE_ID CHANNEL_ID.
+4. Check the source channel.
+5. Check the target channel.
+
+**Expected**
+
+1. A list of recent messages with IDs is returned.
+2. A list of channels with IDs is returned.
+3. An ephemeral message confirms the copy: Thread copy complete.
+4. The original message is still present in the source channel. A bot reply
+   is added: A copy of this thread has been made: .
+5. The message appears in the target channel with the original content and
+   user attribution. A bot message states: This thread was copied from another
+   channel.

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6020.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6020.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy a single message to another channel'
-status: Draft
+status: Active
 priority: High
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6021.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6021.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy a thread with multiple messages to another channel'
-status: Draft
+status: Active
 priority: High
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6021.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6021.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy a thread with multiple messages to another channel'
+status: Draft
+priority: High
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6021
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6021: Copy a thread with multiple messages to another channel
+
+---
+
+**Objective**
+
+Verify that an entire thread is copied to the target channel preserving all
+messages while originals remain intact.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist (source and target) and the user is a member of
+both.
+A thread with at least 3 replies exists in the source channel.
+
+---
+
+**Step 1**
+
+1. Note the root message ID and content of all messages in the source
+   thread.
+2. Run /wrangler copy thread ROOT_MESSAGE_ID TARGET_CHANNEL_ID from the
+   source channel.
+3. Check the source channel.
+4. Check the target channel.
+
+**Expected**
+
+1. Root message ID and thread contents are noted.
+2. An ephemeral confirmation is returned: Thread copy complete.
+3. The entire original thread is still present in the source channel. A bot
+   reply is added to the original thread with a link to the copy.
+4. All messages appear in the target channel as a new thread. Message
+   order, content, and user attribution are preserved.

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6022.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6022.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy thread preserves original messages in source channel'
-status: Draft
+status: Active
 priority: High
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6022.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6022.md
@@ -1,0 +1,71 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy thread preserves original messages in source channel'
+status: Draft
+priority: High
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6022
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6022: Copy thread preserves original messages in source channel
+
+---
+
+**Objective**
+
+Verify that after copying a thread the original messages in the source
+channel are completely unmodified.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A thread with replies exists in the source channel.
+
+---
+
+**Step 1**
+
+1. In the source channel note the exact content, timestamps, reactions, and
+   attachments of all messages in the thread.
+2. Run /wrangler copy thread ROOT_MESSAGE_ID TARGET_CHANNEL_ID.
+3. Compare the original thread messages against the previously noted
+   content.
+
+**Expected**
+
+1. Thread details are noted.
+2. The copy completes successfully.
+3. All original messages remain exactly as they were before the copy,
+   including content, timestamps, reactions, and attachments. The only
+   addition is a bot reply with a link to the copy.

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6023.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6023.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy thread preserves file attachments'
+status: Draft
+priority: Normal
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6023
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6023: Copy thread preserves file attachments
+
+---
+
+**Objective**
+
+Verify that file attachments are preserved when a message or thread is
+copied to another channel.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A message with one or more file attachments exists in the source channel.
+
+---
+
+**Step 1**
+
+1. In the source channel post a message with a file attachment.
+2. Run /wrangler copy thread MESSAGE_ID TARGET_CHANNEL_ID.
+3. Open the copied message in the target channel.
+4. Click on the file attachment in the target channel.
+
+**Expected**
+
+1. The message with attachment is posted.
+2. The copy completes successfully.
+3. The copied message shows the same file attachment(s) as the original.
+4. The file downloads successfully and the content matches the original
+   file.

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6023.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6023.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy thread preserves file attachments'
-status: Draft
+status: Active
 priority: Normal
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6024.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6024.md
@@ -1,0 +1,68 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy thread adds backlink on original thread'
+status: Draft
+priority: Normal
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6024
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6024: Copy thread adds backlink on original thread
+
+---
+
+**Objective**
+
+Verify that after copying a thread a bot reply is added to the original
+thread with a link to the new copy.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A thread exists in the source channel.
+
+---
+
+**Step 1**
+
+1. Run /wrangler copy thread ROOT_MESSAGE_ID TARGET_CHANNEL_ID.
+2. Open the original thread in the source channel.
+3. Click the link in the bot reply.
+
+**Expected**
+
+1. The copy completes successfully.
+2. A bot reply from Wrangler is present at the end of the original thread
+   stating: A copy of this thread has been made: .
+3. Clicking the link navigates to the copied thread in the target channel.

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6024.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6024.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy thread adds backlink on original thread'
-status: Draft
+status: Active
 priority: Normal
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6025.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6025.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy thread sends DM to original author when executor differs'
-status: Draft
+status: Active
 priority: Normal
 folder: Copy Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/copy-thread/MM-T6025.md
+++ b/data/test-cases/plugins/wrangler/copy-thread/MM-T6025.md
@@ -1,0 +1,69 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy thread sends DM to original author when executor differs'
+status: Draft
+priority: Normal
+folder: Copy Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6025
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6025: Copy thread sends DM to original author when executor differs
+
+---
+
+**Objective**
+
+Verify that the original thread author receives a DM from the Wrangler bot
+when a different user copies their thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and both users are authorized.
+Two public channels exist.
+User A has posted a message in the source channel.
+User B is a different user who is a member of both channels.
+
+---
+
+**Step 1**
+
+1. As User A post a message in the source channel.
+2. As User B run /wrangler copy thread MESSAGE_ID TARGET_CHANNEL_ID.
+3. As User A check direct messages from the Wrangler bot.
+
+**Expected**
+
+1. Message is posted by User A.
+2. The copy completes successfully.
+3. User A receives a DM from the Wrangler bot containing a notification
+   about the copied thread and a link to the new location.

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6032.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6032.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'List channels shows joined channels grouped by team'
-status: Draft
+status: Active
 priority: High
 folder: List Commands
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6032.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6032.md
@@ -1,0 +1,66 @@
+---
+# (Required) Ensure all values are filled up
+name: 'List channels shows joined channels grouped by team'
+status: Draft
+priority: High
+folder: List Commands
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6032
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6032: List channels shows joined channels grouped by team
+
+---
+
+**Objective**
+
+Verify that the list channels command returns all joined channels grouped
+by team name.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+The user is a member of channels across at least two teams.
+
+---
+
+**Step 1**
+
+1. Run /wrangler list channels.
+2. Review the returned output.
+
+**Expected**
+
+1. The command executes successfully.
+2. An ephemeral message is returned showing channels grouped by team. Each
+   channel entry shows the channel ID and channel name. DM and GM channels are
+   excluded from the list.

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6033.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6033.md
@@ -1,0 +1,68 @@
+---
+# (Required) Ensure all values are filled up
+name: 'List messages shows recent messages from current channel'
+status: Draft
+priority: High
+folder: List Commands
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6033
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6033: List messages shows recent messages from current channel
+
+---
+
+**Objective**
+
+Verify that the list messages command returns recent message IDs from the
+current channel.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+The current channel has at least 5 recent messages.
+
+---
+
+**Step 1**
+
+1. Navigate to a channel with recent messages.
+2. Run /wrangler list messages.
+3. Review the returned output.
+
+**Expected**
+
+1. Channel is open.
+2. The command executes successfully.
+3. An ephemeral message is returned showing up to 20 recent messages. Each
+   entry shows the message ID and a trimmed preview of the message content.
+   System messages are displayed with a skipped placeholder.

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6033.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6033.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'List messages shows recent messages from current channel'
-status: Draft
+status: Active
 priority: High
 folder: List Commands
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6034.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6034.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: '/wrangler info displays plugin information'
+status: Draft
+priority: Normal
+folder: List Commands
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6034
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6034: /wrangler info displays plugin information
+
+---
+
+**Objective**
+
+Verify that /wrangler info returns plugin version and build information.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+
+---
+
+**Step 1**
+
+1. Run /wrangler info.
+2. Review the returned plugin information.
+
+**Expected**
+
+1. The command executes successfully.
+2. An ephemeral message is returned showing the plugin version, build hash,
+   and build date.

--- a/data/test-cases/plugins/wrangler/list-commands/MM-T6034.md
+++ b/data/test-cases/plugins/wrangler/list-commands/MM-T6034.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: '/wrangler info displays plugin information'
-status: Draft
+status: Active
 priority: Normal
 folder: List Commands
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/merge-thread/MM-T6030.md
+++ b/data/test-cases/plugins/wrangler/merge-thread/MM-T6030.md
@@ -1,0 +1,73 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Merge a thread into an older thread'
+status: Draft
+priority: High
+folder: Merge Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6030
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6030: Merge a thread into an older thread
+
+---
+
+**Objective**
+
+Verify that all messages from a source thread can be merged into an older
+target thread using the slash command.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+MergeThreadEnable is set to true.
+A public channel contains two threads. The target thread was created before
+the source thread.
+
+---
+
+**Step 1**
+
+1. Note the root message IDs of both threads and the content of all
+   messages in the source thread.
+2. Run /wrangler merge thread SOURCE_ROOT_ID TARGET_ROOT_ID.
+3. Check the source thread location.
+4. Open the target thread.
+
+**Expected**
+
+1. Both root IDs and source thread contents are noted.
+2. An ephemeral confirmation is returned: A thread with N message(s) has
+   been merged: .
+3. The source thread is deleted from the channel.
+4. All messages from the source thread now appear as replies in the target
+   thread. Message content and user attribution are preserved.

--- a/data/test-cases/plugins/wrangler/merge-thread/MM-T6030.md
+++ b/data/test-cases/plugins/wrangler/merge-thread/MM-T6030.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Merge a thread into an older thread'
-status: Draft
+status: Active
 priority: High
 folder: Merge Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/merge-thread/MM-T6031.md
+++ b/data/test-cases/plugins/wrangler/merge-thread/MM-T6031.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Merge thread preserves file attachments and reactions'
-status: Draft
+status: Active
 priority: Normal
 folder: Merge Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/merge-thread/MM-T6031.md
+++ b/data/test-cases/plugins/wrangler/merge-thread/MM-T6031.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Merge thread preserves file attachments and reactions'
+status: Draft
+priority: Normal
+folder: Merge Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6031
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6031: Merge thread preserves file attachments and reactions
+
+---
+
+**Objective**
+
+Verify that file attachments and emoji reactions are preserved when merging
+a thread into another thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+MergeThreadEnable is set to true.
+A public channel contains two threads where the target is older. The source
+thread has messages with file attachments and emoji reactions.
+
+---
+
+**Step 1**
+
+1. Note the file attachments and reactions on messages in the source
+   thread.
+2. Run /wrangler merge thread SOURCE_ROOT_ID TARGET_ROOT_ID.
+3. Open the target thread and locate the merged messages.
+4. Verify file attachments by clicking on them.
+5. Verify reactions on the merged messages.
+
+**Expected**
+
+1. Attachments and reactions are noted.
+2. The merge completes successfully.
+3. The merged messages appear in the target thread with original content
+   preserved.
+4. File attachments download successfully and match the original files.
+5. Emoji reactions from the same users are present on the merged messages.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6013.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6013.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move a single message to another channel'
-status: Draft
+status: Active
 priority: High
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6013.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6013.md
@@ -1,0 +1,77 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move a single message to another channel'
+status: Draft
+priority: High
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6013
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6013: Move a single message to another channel
+
+---
+
+**Objective**
+
+Verify that a single standalone message can be moved to another channel
+using the slash command.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist (source and target) and the user is a member of
+both.
+A standalone message (no replies) exists in the source channel.
+
+---
+
+**Step 1**
+
+1. In the source channel run /wrangler list messages to obtain the message
+   ID.
+2. Run /wrangler list channels to obtain the target channel ID.
+3. Run /wrangler move thread MESSAGE_ID CHANNEL_ID.
+4. Check the source channel.
+5. Check the target channel.
+
+**Expected**
+
+1. A list of recent messages with IDs is returned.
+2. A list of channels with IDs is returned.
+3. An ephemeral message confirms the move with a link to the new location:
+   A message has been moved: .
+4. The original message is deleted from the source channel. A summary
+   message from the Wrangler bot is posted indicating the message was moved.
+5. The message appears in the target channel with the original content and
+   user attribution. A bot message states: This thread was moved from another
+   channel.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6014.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6014.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move a thread with multiple messages to another channel'
+status: Draft
+priority: High
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6014
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6014: Move a thread with multiple messages to another channel
+
+---
+
+**Objective**
+
+Verify that an entire thread (root message plus replies) is moved to the
+target channel preserving message order and attribution.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist (source and target) and the user is a member of
+both.
+A thread with at least 3 replies exists in the source channel.
+
+---
+
+**Step 1**
+
+1. Note the root message ID and content of all messages in the thread.
+2. Run /wrangler move thread ROOT_MESSAGE_ID TARGET_CHANNEL_ID from the
+   source channel.
+3. Check the source channel.
+4. Check the target channel.
+
+**Expected**
+
+1. Root message ID and thread contents are noted.
+2. An ephemeral confirmation is returned: A thread with N messages has been
+   moved: .
+3. The entire original thread is deleted from the source channel. A summary
+   message is posted by the Wrangler bot.
+4. All messages appear in the target channel as a new thread. Message
+   order, content, and user attribution are preserved.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6014.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6014.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move a thread with multiple messages to another channel'
-status: Draft
+status: Active
 priority: High
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6015.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6015.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread preserves file attachments'
+status: Draft
+priority: High
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6015
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6015: Move thread preserves file attachments
+
+---
+
+**Objective**
+
+Verify that file attachments are preserved when a message or thread is
+moved to another channel.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A message with one or more file attachments exists in the source channel.
+
+---
+
+**Step 1**
+
+1. In the source channel post a message with a file attachment.
+2. Run /wrangler move thread MESSAGE_ID TARGET_CHANNEL_ID.
+3. Open the moved message in the target channel.
+4. Click on the file attachment in the target channel.
+
+**Expected**
+
+1. The message with attachment is posted.
+2. The move completes successfully.
+3. The moved message shows the same file attachment(s) as the original.
+4. The file downloads successfully and the content matches the original
+   file.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6015.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6015.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread preserves file attachments'
-status: Draft
+status: Active
 priority: High
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6016.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6016.md
@@ -1,0 +1,71 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread preserves reactions'
+status: Draft
+priority: Normal
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6016
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6016: Move thread preserves reactions
+
+---
+
+**Objective**
+
+Verify that emoji reactions are preserved when a message or thread is moved
+to another channel.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A message with emoji reactions from one or more users exists in the source
+channel.
+
+---
+
+**Step 1**
+
+1. In the source channel locate a message that has emoji reactions.
+2. Note which reactions and which users added them.
+3. Run /wrangler move thread MESSAGE_ID TARGET_CHANNEL_ID.
+4. Open the moved message in the target channel.
+
+**Expected**
+
+1. The message with reactions is identified.
+2. Reactions and users are noted.
+3. The move completes successfully.
+4. The moved message in the target channel has the same emoji reactions
+   from the same users as the original.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6016.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6016.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread preserves reactions'
-status: Draft
+status: Active
 priority: Normal
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6017.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6017.md
@@ -1,0 +1,70 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread shows root message in summary by default'
+status: Draft
+priority: Normal
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6017
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6017: Move thread shows root message in summary by default
+
+---
+
+**Objective**
+
+Verify that the post-move summary message in the source channel includes a
+quoted excerpt of the root message by default.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+Two public channels exist and the user is a member of both.
+A message with recognizable text content exists in the source channel.
+
+---
+
+**Step 1**
+
+1. Post a message with distinctive text in the source channel.
+2. Run /wrangler move thread MESSAGE_ID TARGET_CHANNEL_ID (without the
+   --show-root-message-in-summary flag).
+3. Read the Wrangler bot summary message in the source channel.
+
+**Expected**
+
+1. Message is posted.
+2. The move completes successfully.
+3. The summary message includes a quoted excerpt of the original root
+   message text (up to 500 characters) along with the link to the new
+   location.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6017.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6017.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread shows root message in summary by default'
-status: Draft
+status: Active
 priority: Normal
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6018.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6018.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread sends DM to original author when executor differs'
-status: Draft
+status: Active
 priority: Normal
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6018.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6018.md
@@ -1,0 +1,69 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread sends DM to original author when executor differs'
+status: Draft
+priority: Normal
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6018
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6018: Move thread sends DM to original author when executor differs
+
+---
+
+**Objective**
+
+Verify that the original thread author receives a DM from the Wrangler bot
+when a different user moves their thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and both users are authorized.
+Two public channels exist.
+User A has posted a message in the source channel.
+User B is a different user who is a member of both channels.
+
+---
+
+**Step 1**
+
+1. As User A post a message in the source channel.
+2. As User B run /wrangler move thread MESSAGE_ID TARGET_CHANNEL_ID.
+3. As User A check direct messages from the Wrangler bot.
+
+**Expected**
+
+1. Message is posted by User A.
+2. The move completes successfully.
+3. User A receives a DM from the Wrangler bot containing a notification
+   about the moved thread and a link to the new location.

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6019.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6019.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread across teams when enabled'
-status: Draft
+status: Active
 priority: Normal
 folder: Move Thread
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/move-thread/MM-T6019.md
+++ b/data/test-cases/plugins/wrangler/move-thread/MM-T6019.md
@@ -1,0 +1,72 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread across teams when enabled'
+status: Draft
+priority: Normal
+folder: Move Thread
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6019
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6019: Move thread across teams when enabled
+
+---
+
+**Objective**
+
+Verify that a thread can be moved to a channel on a different team when
+cross-team moves are enabled.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+MoveThreadToAnotherTeamEnable is set to true.
+Two teams exist with public channels and the user is a member of channels
+in both teams.
+A message exists in a channel on Team A.
+
+---
+
+**Step 1**
+
+1. In Team A source channel note the message ID.
+2. Run /wrangler list channels to obtain the target channel ID on Team B.
+3. Run /wrangler move thread MESSAGE_ID TEAM_B_CHANNEL_ID.
+4. Navigate to Team B and open the target channel.
+
+**Expected**
+
+1. Message ID is noted.
+2. The target channel ID on Team B is identified.
+3. The move completes successfully with a confirmation message.
+4. The message appears in the target channel on Team B with original
+   content and user attribution preserved.

--- a/data/test-cases/plugins/wrangler/setup/MM-T6009.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6009.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Plugin activation with valid configuration'
-status: Draft
+status: Active
 priority: High
 folder: Setup
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/setup/MM-T6009.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6009.md
@@ -1,0 +1,68 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Plugin activation with valid configuration'
+status: Draft
+priority: High
+folder: Setup
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6009
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6009: Plugin activation with valid configuration
+
+---
+
+**Objective**
+
+Verify that the Wrangler plugin activates successfully and creates the
+wrangler bot user when valid server settings are configured.
+
+---
+
+**Precondition**
+
+Mattermost server v7.1.0 or later is running.
+ServiceSettings.EnablePostUsernameOverride is set to true.
+ServiceSettings.EnablePostIconOverride is set to true.
+
+---
+
+**Step 1**
+
+1. Upload and enable the Wrangler plugin from System Console > Plugins.
+2. Observe the plugin status in the plugin management page.
+3. Run /wrangler info in any channel.
+
+**Expected**
+
+1. Plugin uploads without error.
+2. Plugin status shows as running. A bot user named wrangler is created.
+3. Plugin version and build information are returned as an ephemeral
+   message.

--- a/data/test-cases/plugins/wrangler/setup/MM-T6010.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6010.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Permission - only system admins can use wrangler (default)'
-status: Draft
+status: Active
 priority: High
 folder: Setup
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/setup/MM-T6010.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6010.md
@@ -1,0 +1,66 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Permission - only system admins can use wrangler (default)'
+status: Draft
+priority: High
+folder: Setup
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6010
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6010: Permission - only system admins can use wrangler (default)
+
+---
+
+**Objective**
+
+Verify that only system admin users can execute wrangler commands when the
+default permission setting is active.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled.
+PermittedWranglerUsers is set to system-admins (default).
+A system admin user and a regular user are available.
+
+---
+
+**Step 1**
+
+1. As a system admin user run /wrangler info.
+2. As a regular (non-admin) user run /wrangler info.
+
+**Expected**
+
+1. Plugin info is returned successfully.
+2. An error message is returned indicating the user is not authorized to
+   use the plugin.

--- a/data/test-cases/plugins/wrangler/setup/MM-T6011.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6011.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Permission - system admins and allowed email domain'
-status: Draft
+status: Active
 priority: Normal
 folder: Setup
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/setup/MM-T6011.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6011.md
@@ -1,0 +1,72 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Permission - system admins and allowed email domain'
+status: Draft
+priority: Normal
+folder: Setup
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6011
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6011: Permission - system admins and allowed email domain
+
+---
+
+**Objective**
+
+Verify that system admins and users with matching email domains can use
+wrangler while users with non-matching domains are denied.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled.
+PermittedWranglerUsers is set to system-admins-and-email-domain.
+AllowedEmailDomain is set to a valid domain (e.g. example.com).
+A system admin user, a regular user with a matching email domain, and a
+regular user with a non-matching email domain are available.
+
+---
+
+**Step 1**
+
+1. As a system admin user run /wrangler info.
+2. As a regular user whose email matches the allowed domain run /wrangler
+   info.
+3. As a regular user whose email does not match the allowed domain run
+   /wrangler info.
+
+**Expected**
+
+1. Plugin info is returned successfully.
+2. Plugin info is returned successfully.
+3. An error message is returned indicating the user is not authorized to
+   use the plugin.

--- a/data/test-cases/plugins/wrangler/setup/MM-T6012.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6012.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Permission - all users permitted'
+status: Draft
+priority: Normal
+folder: Setup
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6012
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6012: Permission - all users permitted
+
+---
+
+**Objective**
+
+Verify that any user can execute wrangler commands when the all-users
+permission is configured.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled.
+PermittedWranglerUsers is set to all-users.
+A regular (non-admin) user is available.
+
+---
+
+**Step 1**
+
+1. As a regular (non-admin) user run /wrangler info.
+
+**Expected**
+
+1. Plugin info is returned successfully.

--- a/data/test-cases/plugins/wrangler/setup/MM-T6012.md
+++ b/data/test-cases/plugins/wrangler/setup/MM-T6012.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Permission - all users permitted'
-status: Draft
+status: Active
 priority: Normal
 folder: Setup
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6035.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6035.md
@@ -1,0 +1,71 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread modal opens from post dropdown menu'
+status: Draft
+priority: High
+folder: Web UI
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6035
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6035: Move thread modal opens from post dropdown menu
+
+---
+
+**Objective**
+
+Verify that the Move/Copy Thread option appears in the post dropdown menu
+and opens the move thread modal.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+EnableWebUI is set to true.
+A message exists in a public channel.
+
+---
+
+**Step 1**
+
+1. Hover over a message in the channel and click the three-dot menu (post
+   actions menu).
+2. Click Move/Copy Message (or Move/Copy Thread if the post has replies).
+3. Observe the modal that opens.
+
+**Expected**
+
+1. The post dropdown menu shows a Move/Copy Message or Move/Copy Thread
+   option.
+2. The modal opens.
+3. The modal displays: action type radio buttons (Move and Copy), a team
+   selector dropdown, a channel selector dropdown, and the root message
+   content in a read-only text area.

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6035.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6035.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread modal opens from post dropdown menu'
-status: Draft
+status: Active
 priority: High
 folder: Web UI
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6036.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6036.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Move thread modal allows selecting team and channel'
-status: Draft
+status: Active
 priority: Normal
 folder: Web UI
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6036.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6036.md
@@ -1,0 +1,76 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Move thread modal allows selecting team and channel'
+status: Draft
+priority: Normal
+folder: Web UI
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6036
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6036: Move thread modal allows selecting team and channel
+
+---
+
+**Objective**
+
+Verify that the move thread modal allows selecting a team and then a
+channel and successfully moves the thread.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+EnableWebUI is set to true.
+The user is a member of channels across at least two teams.
+A message exists in a public channel.
+
+---
+
+**Step 1**
+
+1. Open the move thread modal from a post dropdown menu.
+2. Select Move as the action type.
+3. Select a team from the team dropdown.
+4. Select a target channel from the channel dropdown.
+5. Click the Move button.
+6. Check the target channel.
+
+**Expected**
+
+1. Modal is open with the root message displayed.
+2. Move is selected. Additional checkboxes appear: Show root message in
+   move summary and Silence all Wrangler informational messages.
+3. The channel dropdown populates with channels from the selected team.
+4. A target channel is selected.
+5. The button shows a processing state and then the modal closes.
+6. The message appears in the target channel with original content and
+   attribution preserved.

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6037.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6037.md
@@ -1,0 +1,75 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Copy thread via modal preserves original messages'
+status: Draft
+priority: Normal
+folder: Web UI
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6037
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6037: Copy thread via modal preserves original messages
+
+---
+
+**Objective**
+
+Verify that copying a thread via the web UI modal preserves the original
+thread in the source channel.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+EnableWebUI is set to true.
+A thread with replies exists in a public channel.
+
+---
+
+**Step 1**
+
+1. Open the move thread modal from the root post dropdown menu of a thread.
+2. Select Copy as the action type.
+3. Select a team and target channel.
+4. Click the Copy button.
+5. Check the source channel.
+6. Check the target channel.
+
+**Expected**
+
+1. Modal opens showing the root message content.
+2. Copy is selected. The move-specific checkboxes are hidden.
+3. Team and channel are selected.
+4. The button shows a processing state and then the modal closes.
+5. The original thread is still present and unmodified in the source
+   channel. A bot reply with a link to the copy is added.
+6. All messages from the thread appear in the target channel with original
+   content and attribution preserved.

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6037.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6037.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Copy thread via modal preserves original messages'
-status: Draft
+status: Active
 priority: Normal
 folder: Web UI
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6038.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6038.md
@@ -1,0 +1,78 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Attach message via post dropdown two-phase interaction'
+status: Draft
+priority: Normal
+folder: Web UI
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6038
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6038: Attach message via post dropdown two-phase interaction
+
+---
+
+**Objective**
+
+Verify the two-phase attach message interaction through the post dropdown
+menu.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+EnableWebUI is set to true.
+MergeThreadEnable is set to false.
+A public channel contains a thread and a separate standalone message.
+
+---
+
+**Step 1**
+
+1. Hover over the standalone message and open the three-dot menu.
+2. Click Attach to Thread.
+3. Observe the left sidebar.
+4. Hover over a message in the target thread and open the three-dot menu.
+5. Click Attach to this Thread.
+6. Check the target thread.
+
+**Expected**
+
+1. The post dropdown menu shows the Attach to Thread option (only visible
+   on standalone messages).
+2. The message is selected for attaching.
+3. An Attaching Message indicator with a cowboy hat icon appears in the
+   left sidebar header showing a preview of the selected message.
+4. The post dropdown menu now shows an Attach to this Thread option.
+5. The attach operation completes and the left sidebar indicator
+   disappears.
+6. The standalone message now appears as a reply in the target thread with
+   original content preserved.

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6038.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6038.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Attach message via post dropdown two-phase interaction'
-status: Draft
+status: Active
 priority: Normal
 folder: Web UI
 authors: '@ogi-m'

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6039.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6039.md
@@ -1,0 +1,67 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Web UI features hidden when EnableWebUI is disabled'
+status: Draft
+priority: Normal
+folder: Web UI
+authors: '@ogi-m'
+team_ownership:
+  - Core Features
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Plugins
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6039
+created_on: null
+last_updated: ''
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6039: Web UI features hidden when EnableWebUI is disabled
+
+---
+
+**Objective**
+
+Verify that no web UI elements (post dropdown items and channel header
+actions and sidebar indicators) are visible when EnableWebUI is disabled.
+
+---
+
+**Precondition**
+
+Wrangler plugin is enabled and the user is authorized.
+EnableWebUI is set to false (default).
+
+---
+
+**Step 1**
+
+1. Hover over a message and open the three-dot menu.
+2. Check the channel header menu.
+3. Check the left sidebar header area.
+
+**Expected**
+
+1. No Move/Copy Message or Move/Copy Thread or Attach to Thread or Merge to
+   thread options appear in the post dropdown menu.
+2. No Copy Messages to Channel option appears in the channel header menu.
+3. No Wrangler-related indicators appear in the left sidebar header.

--- a/data/test-cases/plugins/wrangler/web-ui/MM-T6039.md
+++ b/data/test-cases/plugins/wrangler/web-ui/MM-T6039.md
@@ -1,7 +1,7 @@
 ---
 # (Required) Ensure all values are filled up
 name: 'Web UI features hidden when EnableWebUI is disabled'
-status: Draft
+status: Active
 priority: Normal
 folder: Web UI
 authors: '@ogi-m'


### PR DESCRIPTION
<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary
- Adds 31 test cases for the Wrangler plugin under data/test-cases/plugins/wrangler
- Covers core user workflows: setup/permissions, move thread, copy thread, attach message, merge thread, list commands, and web UI interactions
- Includes Zephyr-assigned keys MM-T6009 through MM-T6039

#### Coverage
- Setup & permissions: plugin activation, system-admin-only access, email domain filtering, all-users mode
- Move thread flows:
  - Single message and multi-message thread moves
  - File attachment and reaction preservation
  - Root message summary display
  - DM notification to original author when executor differs
  - Cross-team moves
- Copy thread flows:
  - Single message and multi-message thread copies
  - Source channel message preservation
  - Backlink added to original thread
  - File attachment preservation and DM notifications
- Attach message: standalone message attachment to existing threads, file/reaction preservation, DM notifications
- Merge thread: merging source thread into older target thread, file/reaction preservation
- List commands: /wrangler list channels, /wrangler list messages, /wrangler info
- Web UI (beta):
  - Move/copy modal from post dropdown menu with team/channel selection
  - Two-phase attach message interaction via post dropdown
  - Web UI elements hidden when EnableWebUI is disabled
#### Is the feature in stable branch or under review?
- [X] Feature in stable branch (master, main)?
- [] Feature still under review? If yes, list all related pull requests for reference.

#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
- [X] Browser
- [] Mobile App (version, OS)
- [X] Desktop App (version, OS)
