### PR TITLE
adding servicenow plugin test cases

### DIFF
--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6040.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6040.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Connect to ServiceNow via slash command'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6040
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6040: Connect to ServiceNow via slash command
+
+**Objective**
+
+Verify a user can connect their Mattermost account to ServiceNow using the /servicenow connect slash command.
+
+**Precondition**
+
+Plugin is installed and configured with valid ServiceNow OAuth credentials.\
+User is logged into Mattermost and is not yet connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In any Mattermost channel, type /servicenow connect and send the message.\
+2\. Click the link in the ephemeral response to start the OAuth flow.\
+3\. Log in to ServiceNow and approve access when prompted.
+
+**Test Data**
+
+Slash command: /servicenow connect
+
+**Expected**
+
+1\. An ephemeral message is shown with a link to start the OAuth flow.\
+2\. The ServiceNow login/consent page opens in the browser.\
+3\. The user is redirected back and a DM from the ServiceNow bot confirms a successful connection.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6041.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6041.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Disconnect from ServiceNow via slash command'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6041
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6041: Disconnect from ServiceNow via slash command
+
+**Objective**
+
+Verify a user can disconnect their Mattermost account from ServiceNow using the /servicenow disconnect slash command.
+
+**Precondition**
+
+User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In any Mattermost channel, type /servicenow disconnect and send the message.\
+2\. Confirm disconnection if prompted.
+
+**Test Data**
+
+Slash command: /servicenow disconnect
+
+**Expected**
+
+1\. A confirmation message is shown.\
+2\. A DM from the ServiceNow bot confirms the disconnection. Subscription-related slash commands now prompt the user to connect again.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6042.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6042.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Subscription slash commands are guarded when disconnected'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6042
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6042: Subscription slash commands are guarded when disconnected
+
+**Objective**
+
+Verify that subscription-related actions cannot be performed by a user who is not connected.
+
+**Precondition**
+
+User is not connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. Ensure the user is disconnected from ServiceNow.\
+2\. Run /servicenow subscriptions list.\
+3\. Run /servicenow subscriptions add.
+
+**Test Data**
+
+Slash commands: /servicenow subscriptions list, /servicenow subscriptions add
+
+**Expected**
+
+1\. The user is in a disconnected state.\
+2\. The user is informed they must connect first and is given a way to do so.\
+3\. The user is informed they must connect first and is given a way to do so.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6043.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6043.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Slash command help shows supported subcommands'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6043
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6043: Slash command help shows supported subcommands
+
+**Objective**
+
+Verify the /servicenow help command displays all supported subcommands.
+
+**Precondition**
+
+Plugin is enabled. User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In any channel, type /servicenow help and send the message.
+
+**Test Data**
+
+Slash command: /servicenow help
+
+**Expected**
+
+An ephemeral message lists all supported subcommands (connect, disconnect, subscriptions, share, help, etc.) with brief descriptions.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6044.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6044.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Unknown subcommand returns help or error'
+status: Active
+priority: Low
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P4 - Low-Impact (Edge or unsuitable to repeat?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6044
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6044: Unknown subcommand returns help or error
+
+**Objective**
+
+Verify that an unknown /servicenow subcommand returns an error or help message rather than failing silently.
+
+**Precondition**
+
+Plugin is enabled. User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In any channel, type /servicenow foo and send the message.
+
+**Test Data**
+
+Slash command: /servicenow foo
+
+**Expected**
+
+An ephemeral message informs the user that the subcommand is unknown and/or displays the help text.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6045.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6045.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Open the create subscription wizard'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6045
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6045: Open the create subscription wizard
+
+**Objective**
+
+Verify that the create subscription wizard modal can be opened via slash command.
+
+**Precondition**
+
+User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /servicenow subscriptions add.
+
+**Test Data**
+
+Slash command: /servicenow subscriptions add
+
+**Expected**
+
+The create subscription wizard modal opens with options for record subscription and bulk subscription.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6046.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6046.md
@@ -1,0 +1,67 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Create a record subscription for an incident'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6046
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6046: Create a record subscription for an incident
+
+**Objective**
+
+Verify that a record-specific subscription can be created for a ServiceNow incident.
+
+**Precondition**
+
+User is connected to ServiceNow. Incident MM-TEST-INC-01 exists in ServiceNow.
+
+---
+
+**Step 1**
+
+1\. Open the subscription wizard.\
+2\. Select Record subscription.\
+3\. Select record type Incident and search for MM-TEST-INC-01.\
+4\. Select events 'State changed' and 'New comment added'.\
+5\. Choose the current channel and submit.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; Events: State changed, New comment added
+
+**Expected**
+
+1\. The wizard opens.\
+2\. Record subscription form is shown.\
+3\. The incident is selectable from the search results.\
+4\. Events are selected.\
+5\. The subscription is saved successfully and appears in the RHS list for the channel.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6047.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6047.md
@@ -1,0 +1,67 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Create a bulk subscription for problem records'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6047
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6047: Create a bulk subscription for problem records
+
+**Objective**
+
+Verify that a bulk subscription can be created for all problem records.
+
+**Precondition**
+
+User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. Open the subscription wizard.\
+2\. Select Bulk subscription.\
+3\. Select record type Problem.\
+4\. Select event 'New record created'.\
+5\. Choose the current channel and submit.
+
+**Test Data**
+
+Record type: Problem; Event: New record created
+
+**Expected**
+
+1\. The wizard opens.\
+2\. Bulk subscription form is shown.\
+3\. The record type is selected.\
+4\. The event is selected.\
+5\. The bulk subscription is saved and appears in the RHS list.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6048.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6048.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Create subscriptions for each supported record type'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6048
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6048: Create subscriptions for each supported record type
+
+**Objective**
+
+Verify subscriptions can be created for all supported record types (incident, problem, change_request).
+
+**Precondition**
+
+User is connected to ServiceNow. Records MM-TEST-INC-01, MM-TEST-PRB-01, and MM-TEST-CHG-01 exist.
+
+---
+
+**Step 1**
+
+1\. Create a record subscription for incident MM-TEST-INC-01.\
+2\. Create a record subscription for problem MM-TEST-PRB-01.\
+3\. Create a record subscription for change_request MM-TEST-CHG-01.
+
+**Test Data**
+
+Records: MM-TEST-INC-01, MM-TEST-PRB-01, MM-TEST-CHG-01
+
+**Expected**
+
+1\. Subscription is saved.\
+2\. Subscription is saved.\
+3\. Subscription is saved. All three appear in the RHS list.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6049.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6049.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Receive notification when subscribed incident state changes'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6049
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6049: Receive notification when subscribed incident state changes
+
+**Objective**
+
+Verify a notification post is created when a subscribed record's state changes in ServiceNow.
+
+**Precondition**
+
+User is connected to ServiceNow. A record subscription exists for incident MM-TEST-INC-01 with the 'State changed' event in the current channel.
+
+---
+
+**Step 1**
+
+1\. In ServiceNow, open incident MM-TEST-INC-01.\
+2\. Change the State field from 'New' to 'In Progress' and click Update.\
+3\. Return to the subscribed Mattermost channel.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; State change: New -> In Progress
+
+**Expected**
+
+1\. Incident form opens.\
+2\. ServiceNow saves the state change.\
+3\. A notification post from the ServiceNow bot appears in the channel describing the state change.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6050.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6050.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Receive notification when a comment is added to a subscribed record'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6050
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6050: Receive notification when a comment is added to a subscribed record
+
+**Objective**
+
+Verify a notification post is created when a new comment is added to a subscribed record in ServiceNow.
+
+**Precondition**
+
+User is connected to ServiceNow. A record subscription exists for incident MM-TEST-INC-01 with the 'New comment added' event in the current channel.
+
+---
+
+**Step 1**
+
+1\. In ServiceNow, open incident MM-TEST-INC-01.\
+2\. In the Comments field (not Work notes), add the text 'Test comment from ServiceNow' and click Update.\
+3\. Return to the subscribed Mattermost channel.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; Comment: Test comment from ServiceNow
+
+**Expected**
+
+1\. Incident form opens.\
+2\. ServiceNow saves the comment.\
+3\. A notification post from the ServiceNow bot appears in the channel showing the new comment.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6051.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6051.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Receive notification when a new record is created (bulk subscription)'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6051
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6051: Receive notification when a new record is created (bulk subscription)
+
+**Objective**
+
+Verify a notification post is created when a new record of a subscribed type is created in ServiceNow.
+
+**Precondition**
+
+User is connected to ServiceNow. A bulk subscription exists for record type Problem with the 'New record created' event in the current channel.
+
+---
+
+**Step 1**
+
+1\. In ServiceNow, navigate to problem.new.\
+2\. Set short description to 'MM-TEST-PRB-NEW' and submit.\
+3\. Return to the subscribed Mattermost channel.
+
+**Test Data**
+
+Record type: Problem; New short description: MM-TEST-PRB-NEW
+
+**Expected**
+
+1\. The new problem form opens.\
+2\. The problem is created in ServiceNow.\
+3\. A notification post from the ServiceNow bot appears in the channel announcing the new problem.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6052.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6052.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'View existing subscriptions in the Right-Hand Sidebar'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6052
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6052: View existing subscriptions in the Right-Hand Sidebar
+
+**Objective**
+
+Verify existing subscriptions are listed in the Right-Hand Sidebar.
+
+**Precondition**
+
+User is connected to ServiceNow. At least one subscription exists for the current channel.
+
+---
+
+**Step 1**
+
+1\. In the subscribed channel, click the ServiceNow icon in the channel header to open the RHS.
+
+**Test Data**
+
+Channel with at least one ServiceNow subscription
+
+**Expected**
+
+The RHS opens and lists the existing subscriptions for the current channel with record type, events, and actions.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6053.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6053.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'List subscriptions via slash command'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6053
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6053: List subscriptions via slash command
+
+**Objective**
+
+Verify subscriptions can be listed via slash command.
+
+**Precondition**
+
+User is connected to ServiceNow. At least one subscription exists.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /servicenow subscriptions list.
+
+**Test Data**
+
+Slash command: /servicenow subscriptions list
+
+**Expected**
+
+A post is returned listing the existing subscriptions.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6054.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6054.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Filter subscriptions in the Right-Hand Sidebar'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6054
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6054: Filter subscriptions in the Right-Hand Sidebar
+
+**Objective**
+
+Verify the RHS filter icon filters the displayed subscriptions.
+
+**Precondition**
+
+User is connected to ServiceNow. Multiple subscriptions exist for the current channel with different record types.
+
+---
+
+**Step 1**
+
+1\. Open the ServiceNow RHS in a channel that contains multiple subscriptions.\
+2\. Click the filter icon.\
+3\. Apply a filter (for example, record type Incident).
+
+**Test Data**
+
+Multiple subscriptions of different record types
+
+**Expected**
+
+1\. The RHS lists all subscriptions.\
+2\. Filter controls appear.\
+3\. Only subscriptions matching the filter are displayed.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6055.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6055.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Filter subscriptions to only those created by me via slash command'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6055
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6055: Filter subscriptions to only those created by me via slash command
+
+**Objective**
+
+Verify a slash command flag can filter subscriptions to only those created by the current user.
+
+**Precondition**
+
+User is connected to ServiceNow. Subscriptions exist created by multiple users.
+
+---
+
+**Step 1**
+
+1\. Run /servicenow subscriptions list me (or the equivalent 'created by me' filter).
+
+**Test Data**
+
+Slash command: /servicenow subscriptions list me
+
+**Expected**
+
+A post is returned listing only subscriptions created by the current user.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6056.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6056.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Edit an existing subscription from the RHS'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6056
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6056: Edit an existing subscription from the RHS
+
+**Objective**
+
+Verify an existing subscription can be edited from the RHS and the changes persist.
+
+**Precondition**
+
+User is connected to ServiceNow. At least one subscription exists in the current channel that the user can edit.
+
+---
+
+**Step 1**
+
+1\. Open the ServiceNow RHS.\
+2\. Click Edit on an existing subscription.\
+3\. In the modal, add or remove an event and save.
+
+**Test Data**
+
+Existing subscription; Toggle event: Priority changed
+
+**Expected**
+
+1\. RHS lists the subscriptions.\
+2\. The edit modal opens prepopulated with the subscription details.\
+3\. The subscription is saved and the RHS reflects the updated event list.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6057.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6057.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Delete a subscription from the RHS'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6057
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6057: Delete a subscription from the RHS
+
+**Objective**
+
+Verify a subscription can be deleted from the RHS.
+
+**Precondition**
+
+User is connected to ServiceNow. At least one subscription exists in the current channel that the user can delete.
+
+---
+
+**Step 1**
+
+1\. Open the ServiceNow RHS.\
+2\. Click Delete on an existing subscription.\
+3\. Confirm the deletion.
+
+**Test Data**
+
+Existing subscription
+
+**Expected**
+
+1\. RHS lists the subscriptions.\
+2\. A confirmation prompt appears.\
+3\. The subscription is removed from the RHS list.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6058.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6058.md
@@ -49,7 +49,7 @@ User is connected to ServiceNow. At least one subscription exists with a known I
 **Step 1**
 
 1\. Note the ID of an existing subscription (from RHS or list command).\
-2\. Run /servicenow subscriptions delete .
+2\. Run /servicenow subscriptions delete <subscription-id>.
 
 **Test Data**
 

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6058.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6058.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Delete a subscription via slash command'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6058
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6058: Delete a subscription via slash command
+
+**Objective**
+
+Verify a subscription can be deleted via slash command.
+
+**Precondition**
+
+User is connected to ServiceNow. At least one subscription exists with a known ID.
+
+---
+
+**Step 1**
+
+1\. Note the ID of an existing subscription (from RHS or list command).\
+2\. Run /servicenow subscriptions delete .
+
+**Test Data**
+
+Slash command: /servicenow subscriptions delete
+
+**Expected**
+
+1\. The subscription ID is known.\
+2\. A confirmation message is shown and the subscription is removed from the list.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6059.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6059.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Open the search and share record modal'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6059
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6059: Open the search and share record modal
+
+**Objective**
+
+Verify the search and share record modal can be opened.
+
+**Precondition**
+
+User is connected to ServiceNow.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /servicenow share (or use the corresponding UI action).
+
+**Test Data**
+
+Slash command: /servicenow share
+
+**Expected**
+
+The search and share record modal opens with options to choose a record type, search, and select a channel.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6060.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6060.md
@@ -1,0 +1,65 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Search and share an incident in a channel'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6060
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6060: Search and share an incident in a channel
+
+**Objective**
+
+Verify an incident can be searched, selected, and shared to a channel as a post.
+
+**Precondition**
+
+User is connected to ServiceNow. Incident MM-TEST-INC-01 exists with short description containing 'MM-TEST'.
+
+---
+
+**Step 1**
+
+1\. Open the share record modal.\
+2\. Select record type Incident and search for 'MM-TEST'.\
+3\. Select MM-TEST-INC-01 from the results.\
+4\. Choose the current channel and click Share.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; Search keyword: MM-TEST
+
+**Expected**
+
+1\. The modal opens.\
+2\. Matching incidents appear in search results.\
+3\. The selected incident is highlighted.\
+4\. A post containing the incident details is created in the chosen channel.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6061.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6061.md
@@ -1,0 +1,65 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Search and share a KB article in a channel'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6061
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6061: Search and share a KB article in a channel
+
+**Objective**
+
+Verify a kb_knowledge article can be searched and shared to a channel.
+
+**Precondition**
+
+User is connected to ServiceNow. KB article MM-TEST-KB-01 exists and is published.
+
+---
+
+**Step 1**
+
+1\. Open the share record modal.\
+2\. Select record type Knowledge and search for 'MM-TEST'.\
+3\. Select MM-TEST-KB-01.\
+4\. Choose the current channel and click Share.
+
+**Test Data**
+
+Record: MM-TEST-KB-01; Search keyword: MM-TEST
+
+**Expected**
+
+1\. The modal opens.\
+2\. Matching KB articles appear in search results.\
+3\. The selected article is highlighted.\
+4\. A post containing the KB article details is created in the chosen channel.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6062.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6062.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'View existing comments on a record from a shared/notification post'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6062
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6062: View existing comments on a record from a shared/notification post
+
+**Objective**
+
+Verify the 'Add and View Comments' modal displays existing comments on the record.
+
+**Precondition**
+
+User is connected to ServiceNow. A notification post or shared record post for incident MM-TEST-INC-01 exists in a channel. MM-TEST-INC-01 has at least one existing comment.
+
+---
+
+**Step 1**
+
+1\. Locate the ServiceNow post for MM-TEST-INC-01 in the channel.\
+2\. Click the 'Add and View Comments' button on the post.
+
+**Test Data**
+
+Record: MM-TEST-INC-01 with at least one existing comment
+
+**Expected**
+
+1\. The post is visible with action buttons.\
+2\. The modal opens and displays existing comments from ServiceNow.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6063.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6063.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Add a new comment to a record from Mattermost'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6063
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6063: Add a new comment to a record from Mattermost
+
+**Objective**
+
+Verify a new comment can be added to a ServiceNow record from Mattermost and is persisted in ServiceNow.
+
+**Precondition**
+
+User is connected to ServiceNow. The 'Add and View Comments' modal is accessible for incident MM-TEST-INC-01.
+
+---
+
+**Step 1**
+
+1\. Open the 'Add and View Comments' modal for MM-TEST-INC-01.\
+2\. Enter 'Comment added from Mattermost' in the new comment field and submit.\
+3\. In ServiceNow, open MM-TEST-INC-01 and inspect its Comments / Activity stream.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; Comment: Comment added from Mattermost
+
+**Expected**
+
+1\. The modal opens.\
+2\. A confirmation appears and the comment is shown in the modal's comment list.\
+3\. The comment 'Comment added from Mattermost' is present on the record in ServiceNow.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6064.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6064.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Add comments to task and change_task records'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6064
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6064: Add comments to task and change_task records
+
+**Objective**
+
+Verify comments can be added to other supported record types (task and change_task).
+
+**Precondition**
+
+User is connected to ServiceNow. Records MM-TEST-TASK-01 (task) and MM-TEST-CTASK-01 (change_task) exist and have shared/notification posts in a channel.
+
+---
+
+**Step 1**
+
+1\. Open the 'Add and View Comments' modal for MM-TEST-TASK-01 and add a comment 'Task comment from MM'.\
+2\. Open the 'Add and View Comments' modal for MM-TEST-CTASK-01 and add a comment 'Change task comment from MM'.\
+3\. Verify both comments in ServiceNow.
+
+**Test Data**
+
+Records: MM-TEST-TASK-01, MM-TEST-CTASK-01; Comments: Task comment from MM, Change task comment from MM
+
+**Expected**
+
+1\. The comment is saved on MM-TEST-TASK-01.\
+2\. The comment is saved on MM-TEST-CTASK-01.\
+3\. Both comments are visible on the respective records in ServiceNow.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6065.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6065.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Open the update state modal from a post'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6065
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6065: Open the update state modal from a post
+
+**Objective**
+
+Verify the 'Update State' modal opens from a record post.
+
+**Precondition**
+
+User is connected to ServiceNow. A notification or shared post for incident MM-TEST-INC-01 exists in a channel.
+
+---
+
+**Step 1**
+
+1\. Locate the ServiceNow post for MM-TEST-INC-01.\
+2\. Click the 'Update State' button on the post.
+
+**Test Data**
+
+Record: MM-TEST-INC-01
+
+**Expected**
+
+1\. The post is visible with action buttons.\
+2\. The 'Update State' modal opens showing the current state of the incident.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6066.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6066.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Update the state of an incident from Mattermost'
+status: Active
+priority: High
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6066
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6066: Update the state of an incident from Mattermost
+
+**Objective**
+
+Verify the state of an incident can be updated from Mattermost and is persisted in ServiceNow.
+
+**Precondition**
+
+User is connected to ServiceNow. The 'Update State' modal is accessible for incident MM-TEST-INC-01 which is currently in a non-terminal state.
+
+---
+
+**Step 1**
+
+1\. Open the 'Update State' modal for MM-TEST-INC-01.\
+2\. Choose a different valid state (for example 'On Hold') and submit.\
+3\. In ServiceNow, open MM-TEST-INC-01 and verify the State field.
+
+**Test Data**
+
+Record: MM-TEST-INC-01; New state: On Hold
+
+**Expected**
+
+1\. The modal shows the current state.\
+2\. A confirmation appears in Mattermost indicating the state was updated.\
+3\. The State field on the record in ServiceNow shows the new value.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6067.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6067.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Update the state of a task record from Mattermost'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6067
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6067: Update the state of a task record from Mattermost
+
+**Objective**
+
+Verify the state of a task record can be updated from Mattermost.
+
+**Precondition**
+
+User is connected to ServiceNow. The 'Update State' modal is accessible for task MM-TEST-TASK-01 which is currently in a non-terminal state.
+
+---
+
+**Step 1**
+
+1\. Open the 'Update State' modal for MM-TEST-TASK-01.\
+2\. Choose a different valid state and submit.\
+3\. In ServiceNow, open MM-TEST-TASK-01 and verify the State field.
+
+**Test Data**
+
+Record: MM-TEST-TASK-01; New state: Work in Progress
+
+**Expected**
+
+1\. The modal shows the current state.\
+2\. A confirmation appears in Mattermost indicating the state was updated.\
+3\. The State field on the record in ServiceNow shows the new value.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6068.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6068.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Configure ServiceNow plugin in the System Console'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6068
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6068: Configure ServiceNow plugin in the System Console
+
+**Objective**
+
+Verify the ServiceNow plugin can be configured and enabled from the System Console without errors.
+
+**Precondition**
+
+User has System Administrator privileges in Mattermost. A ServiceNow instance URL and OAuth client ID/secret are available.
+
+---
+
+**Step 1**
+
+1\. Navigate to System Console > Plugins > ServiceNow.\
+2\. Enter the ServiceNow instance URL, OAuth client ID, and OAuth client secret.\
+3\. Save the configuration and ensure the plugin is enabled.
+
+**Test Data**
+
+ServiceNow instance URL, OAuth client ID, OAuth client secret
+
+**Expected**
+
+1\. The plugin settings page loads.\
+2\. Values are accepted.\
+3\. The plugin is saved and enabled without errors; slash commands and RHS are available in channels.

--- a/data/test-cases/plugins/service-now/sn-phase3/MM-T6069.md
+++ b/data/test-cases/plugins/service-now/sn-phase3/MM-T6069.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Disable the ServiceNow plugin from the System Console'
+status: Active
+priority: Normal
+folder: SN phase3
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6069
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6069: Disable the ServiceNow plugin from the System Console
+
+**Objective**
+
+Verify that disabling the plugin removes its slash commands and RHS integration.
+
+**Precondition**
+
+User has System Administrator privileges in Mattermost. The ServiceNow plugin is enabled.
+
+---
+
+**Step 1**
+
+1\. Navigate to System Console > Plugins > Plugin Management.\
+2\. Disable the ServiceNow plugin.\
+3\. Return to a channel and attempt to use /servicenow commands and open the RHS.
+
+**Test Data**
+
+ServiceNow plugin
+
+**Expected**
+
+1\. The plugin list loads.\
+2\. The plugin is disabled successfully.\
+3\. The /servicenow slash commands are no longer available and the RHS integration is not present.


### PR DESCRIPTION
<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary
Adds 30 new manual test cases for the ServiceNow plugin (https://github.com/mattermost/mattermost-plugin-servicenow) under data/test-cases/plugins/service-now/sn-phase3/, covering happy-path coverage of the plugin's primary user-facing features. Test cases were authored against plugin v2.4.0 (current latest), imported into Zephyr Scale as MM-T6040 through MM-T6069, and reflect the keys assigned by Zephyr on import.
The new cases live in their own sn-phase3/ subfolder to avoid interleaving with the existing MM-T5225..MM-T5293 (root) and MM-T5319..MM-T5338 (sn-phase2/) batches, mirroring the existing phasing precedent.
#### Validation:
- deno task validate: PASSED (all 30 files validated; new folder registered as SN phase3).
- deno task check (fmt): PASSED across the 30 new files.
#### Coverage
30 test cases (MM-T6040..MM-T6069) across 9 functional areas:
- Authentication (3): connect, disconnect, disconnected-state guard.
- Slash Commands (5): help, unknown subcommand, list, list-mine filter, delete by ID.
- Subscriptions (6): open wizard, create record subscription, create bulk subscription, create for each supported record type, edit from RHS, delete from RHS.
- Notifications (3): state change, new comment, new record created (bulk).
- Right-Hand Sidebar (2): list subscriptions, filter subscriptions.
- Search and Share (3): open share modal, share incident, share KB article.
- Comments (3): view existing comments, add comment, comments on task and change_task.
- State Updates (3): open update-state modal, update incident state, update task state.
- Admin (2): configure plugin in System Console, disable plugin.
##### Priority distribution: 6 P1 (smoke), 13 P2 (core), 10 P3 (deep), 1 P4 (edge).
#### Out of Scope (intentionally not covered)
- Negative paths / error states beyond the unknown-subcommand smoke check.
- The cert_follow_on_task record type (requires GRC plugin not present on a fresh PDI).
- Performance, accessibility, or security testing.
- Automated test coverage (Cypress/Playwright/Detox fields left null).
- Reconciliation/dedup with the older MM-T5225..MM-T5293 and sn-phase2 batches - intentionally deferred so this PR does not modify existing test cases.
#### ServiceNow Test Data Required
To execute these tests, the following must exist in a ServiceNow instance:
- OAuth Application Registry entry for the Mattermost plugin (Client ID/Secret).
- Mattermost ServiceNow Update Set imported and committed.
- One ServiceNow user with itil and knowledge roles, member of two assignment groups (MM-TEST-GROUP-A, MM-TEST-GROUP-B).
- Test records (prefix MM-TEST-): one each of incident, problem, change_request, change_task (child of the change_request), task, and one published kb_knowledge article

#### Is the feature in stable branch or under review?
- [x] Feature in stable branch (master, main)?
- [] Feature still under review? If yes, list all related pull requests for reference.


#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
- [x] Browser
- [] Mobile App (version, OS)
- [] Desktop App (version, OS)
