### PR TITLE
test cases for interactive dialogs file upload element

### DIFF
--- a/data/test-cases/integrations/interactive-dialogs/MM-T6070.md
+++ b/data/test-cases/integrations/interactive-dialogs/MM-T6070.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Interactive Dialog - File upload dialog renders with single and multi file fields'
+status: Draft
+priority: Normal
+folder: Interactive Dialogs
+authors: '@ogi-m'
+team_ownership:
+  - Channels
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Interactive Dialogs
+component: null
+tags: []
+labels:
+  - TM4J-Key-Mapped-In-Cypress-Release
+  - cy-prod
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: in Production
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments:
+  - Automated - No manual tests needed
+
+# Do not change
+id: null
+key: MM-T6070
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6070: Interactive Dialog - File upload dialog renders with single and multi file fields
+
+**Objective**
+
+Verify the interactive dialog opens via slash command and renders the file upload elements with correct labels, Choose File / Choose Files buttons based on allow_multiple, help text, and footer buttons.
+
+**Precondition**
+
+Server is not running on Cloud edition.\
+A webhook fixture server is running and reachable from the Mattermost server.\
+A slash command /file_upload_dialog exists on the current team and is wired to the webhook endpoint /file_upload_dialog_request, which returns an interactive dialog with two required file elements (single_document with allow_multiple=false; multiple_files with allow_multiple=true) and an optional description textarea.\
+User is logged into Mattermost and is on a channel in that team.
+
+---
+
+**Step 1**
+
+1\. In the channel input box, type /file_upload_dialog and press Enter.\
+2\. Observe the dialog modal header.\
+3\. Observe the first file upload element (single_document).\
+4\. Observe the second file upload element (multiple_files).\
+5\. Observe the dialog footer.
+
+**Test Data**
+
+Slash command: /file_upload_dialog
+
+**Expected**
+
+1\. The Interactive Dialog modal opens.\
+2\. The header shows the dialog title 'Title for Dialog Test with file upload element'.\
+3\. The first file field shows its display name label 'Upload Single Document', a button labeled 'Choose File', and visible help text.\
+4\. The second file field shows its display name label 'Upload Multiple Files', a button labeled 'Choose Files', and visible help text.\
+5\. The footer shows a 'Cancel' button and a Submit button labeled 'Submit File Upload Test'.

--- a/data/test-cases/integrations/interactive-dialogs/MM-T6071.md
+++ b/data/test-cases/integrations/interactive-dialogs/MM-T6071.md
@@ -1,0 +1,80 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Interactive Dialog - Upload and submit files in single and multi file fields'
+status: Draft
+priority: Normal
+folder: Interactive Dialogs
+authors: '@ogi-m'
+team_ownership:
+  - Channels
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Interactive Dialogs
+component: null
+tags: []
+labels:
+  - TM4J-Key-Mapped-In-Cypress-Release
+  - cy-prod
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: in Production
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments:
+  - Automated - No manual tests needed
+
+# Do not change
+id: null
+key: MM-T6071
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6071: Interactive Dialog - Upload and submit files in single and multi file fields
+
+**Objective**
+
+Verify that uploading a file to each required file element enables Submit, that submission posts the expected payload (single_document as a string file ID, multiple_files as comma-separated IDs, top-level file_ids array containing all uploaded IDs), and that the success confirmation is posted to the channel.
+
+**Precondition**
+
+Server is not running on Cloud edition.\
+A webhook fixture server is running and reachable from the Mattermost server.\
+A slash command /file_upload_dialog exists on the current team and is wired to the webhook endpoint /file_upload_dialog_request, which returns an interactive dialog with two required file elements (single_document with allow_multiple=false; multiple_files with allow_multiple=true) and an optional description textarea.\
+User is logged into Mattermost and is on a channel in that team.
+
+---
+
+**Step 1**
+
+1\. Run /file_upload_dialog to open the dialog.\
+2\. In the single_document field, click Choose File and upload one image file.\
+3\. Wait for the file preview to appear (upload completed).\
+4\. In the multiple_files field, click Choose Files and upload one image file.\
+5\. Wait for the file preview to appear (upload completed).\
+6\. Click the Submit button in the dialog footer.\
+7\. Inspect the network request to /api/v4/actions/dialogs/submit (browser dev tools).\
+8\. Observe the channel for the success post.
+
+**Test Data**
+
+Slash command: /file_upload_dialog; Two small image files
+
+**Expected**
+
+1\. The dialog opens.\
+2\. An upload progress indicator is shown then a completed file preview appears in the single_document field.\
+3\. Submit remains disabled while the upload is in progress.\
+4\. An upload progress indicator is shown then a completed file preview appears in the multiple_files field.\
+5\. Submit becomes enabled once all uploads are settled.\
+6\. The dialog closes after submission.\
+7\. The submitted body contains submission.single_document as a non-empty string (file ID), submission.multiple_files as a non-empty string of comma-separated file IDs, and a top-level file_ids array that includes the single file ID and each ID from multiple_files.\
+8\. A post 'Dialog submitted successfully!' appears in the channel.

--- a/data/test-cases/integrations/interactive-dialogs/MM-T6072.md
+++ b/data/test-cases/integrations/interactive-dialogs/MM-T6072.md
@@ -1,0 +1,74 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Interactive Dialog - allow_multiple appends files, single-file field replaces on re-select'
+status: Draft
+priority: Normal
+folder: Interactive Dialogs
+authors: '@ogi-m'
+team_ownership:
+  - Channels
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Interactive Dialogs
+component: null
+tags: []
+labels:
+  - TM4J-Key-Mapped-In-Cypress-Release
+  - cy-prod
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: in Production
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments:
+  - Automated - No manual tests needed
+
+# Do not change
+id: null
+key: MM-T6072
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6072: Interactive Dialog - allow_multiple appends files, single-file field replaces on re-select
+
+**Objective**
+
+Verify that selecting additional files in an allow_multiple file element appends them to the existing list, while selecting a new file in a single (allow_multiple=false) file element replaces the previously selected file.
+
+**Precondition**
+
+Server is not running on Cloud edition.\
+A webhook fixture server is running and reachable from the Mattermost server.\
+A slash command /file_upload_dialog exists on the current team and is wired to the webhook endpoint /file_upload_dialog_request, which returns an interactive dialog with two required file elements (single_document with allow_multiple=false; multiple_files with allow_multiple=true) and an optional description textarea.\
+User is logged into Mattermost and is on a channel in that team.
+
+---
+
+**Step 1**
+
+1\. Run /file_upload_dialog to open the dialog.\
+2\. In the multiple_files field, upload one image file and wait for the preview.\
+3\. In the multiple_files field, upload a second image file and wait for the preview.\
+4\. In the single_document field, upload one image file and wait for the preview.\
+5\. In the single_document field, upload a different image file and wait for the preview.
+
+**Test Data**
+
+Slash command: /file_upload_dialog; Two small image files
+
+**Expected**
+
+1\. The dialog opens.\
+2\. One completed file preview is shown in the multiple_files field.\
+3\. Two completed file previews are shown in the multiple_files field (the new file was appended, not replacing the first).\
+4\. One completed file preview is shown in the single_document field.\
+5\. Exactly one completed file preview is shown in the single_document field (the new file replaced the previous one).

--- a/data/test-cases/integrations/interactive-dialogs/MM-T6073.md
+++ b/data/test-cases/integrations/interactive-dialogs/MM-T6073.md
@@ -1,0 +1,68 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Interactive Dialog - Submitting without uploading required files shows required error'
+status: Draft
+priority: Normal
+folder: Interactive Dialogs
+authors: '@ogi-m'
+team_ownership:
+  - Channels
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: Interactive Dialogs
+component: null
+tags: []
+labels:
+  - TM4J-Key-Mapped-In-Cypress-Release
+  - cy-prod
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: in Production
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments:
+  - Automated - No manual tests needed
+
+# Do not change
+id: null
+key: MM-T6073
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6073: Interactive Dialog - Submitting without uploading required files shows required error
+
+**Objective**
+
+Verify that submitting the dialog without selecting any files for the required file elements blocks submission and renders an inline 'This field is required' error on the file field.
+
+**Precondition**
+
+Server is not running on Cloud edition.\
+A webhook fixture server is running and reachable from the Mattermost server.\
+A slash command /file_upload_dialog exists on the current team and is wired to the webhook endpoint /file_upload_dialog_request, which returns an interactive dialog with two required file elements (single_document with allow_multiple=false; multiple_files with allow_multiple=true) and an optional description textarea.\
+User is logged into Mattermost and is on a channel in that team.
+
+---
+
+**Step 1**
+
+1\. Run /file_upload_dialog to open the dialog.\
+2\. Without uploading any files, click the Submit button.
+
+**Test Data**
+
+Slash command: /file_upload_dialog
+
+**Expected**
+
+1\. The dialog opens with Submit enabled (no uploads are in progress).\
+2\. The dialog remains open. An inline error 'This field is required' is shown on the first file field (single_document).


### PR DESCRIPTION
<!--
Give the PR a descriptive title following conventional commits - https://www.conventionalcommits.org/en/v1.0.0/

Typical format for test cases:
```
test(feature): general description of tests
or
test(test key): update existing test case description
```

Example:
```
test(mark as unread): latest post should appear unread after marking the channel as unread in RHS via menu option or shortcut key
test(MM-T4886): updating step 2 
```
-->

#### Summary
Adds 4 new manual test cases for the file upload element in interactive dialogs, mirroring the Cypress E2E spec introduced in mattermost/mattermost#36881 (https://github.com/mattermost/mattermost/pull/36881) (Add file upload element to interactive dialogs).
Cases live in the existing data/test-cases/integrations/interactive-dialogs/ folder alongside the established MM-T2491..MM-T2503 and MM-T3835 batch, matching that batch's frontmatter conventions (folder: Interactive Dialogs, location: Interactive Dialogs, team_ownership: [Channels], cypress: in Production, labels: [TM4J-Key-Mapped-In-Cypress-Release, cy-prod], manual_test_environments: [Automated - No manual tests needed]).
#### Validation:
- deno task validate: PASSED (all 4 files registered).
- deno fmt --check: clean across the 4 new files.
#### Coverage
4 test cases (MM-T6070..MM-T6073), one per it() block in e2e-tests/cypress/tests/integration/channels/interactive_dialog/file_upload_spec.js:
- MM-T6070 - File upload dialog renders with single and multi file fields (title, labels, Choose File vs Choose Files buttons, help text, Cancel/Submit footer).
- MM-T6071 - Upload and submit files in single and multi file fields (payload shape: submission.single_document as string ID, submission.multiple_files as comma-separated IDs, top-level file_ids array; success post in channel).
- MM-T6072 - allow_multiple appends files, single-file field replaces on re-select.
- MM-T6073 - Submitting without uploading required files shows the inline "This field is required" error.
All four are Draft, Normal priority, P2 - Core Functions.
#### Out of Scope (intentionally not covered)
- Server-side validation (file ownership, dedup, MaxDialogFileIds limit, smuggled IDs) - covered by Go unit tests in the source PR.
- The AppsFormFileUpload React component internals - covered by Jest tests in the source PR.
- Negative/edge paths beyond the required-field check exercised by the spec.
- Non-Cypress execution environments (Detox, Playwright, MMCTL fields left null).
#### Related
- Source PR (feature + Cypress spec): https://github.com/mattermost/mattermost/pull/36881
- Cypress spec authored by @sbishel; MM-T placeholders in file_upload_spec.js will be replaced with MM-T6070..MM-T6073 once this PR and the source PR settle.
- Jira ticket: MM-66109
#### Is the feature in stable branch or under review?
- [] Feature in stable branch (master, main)?
- [x] Feature still under review? If yes, list all related pull requests for reference.

#### Test server
<!--
Link the test server to be used for testing and trying out the test cases could be from "/cloud", pull request or requirements to set up the test server.
-->

#### Test client
<!--
Indicate test client requirements (version, OS) and/or add link to test artifact in case a feature is still under review.
-->
- [x] Browser
- [] Mobile App (version, OS)
- [] Desktop App (version, OS)
