### PR TITLE
Adding test cases for google meet plugin

### DIFF
--- a/data/test-cases/plugins/google-meet/MM-T6074.md
+++ b/data/test-cases/plugins/google-meet/MM-T6074.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Connect Google account via /meet connect'
+status: Active
+priority: High
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6074
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6074: Connect Google account via /meet connect
+
+**Objective**
+
+Verify a user can connect their Mattermost account to Google via the /meet connect slash command and the OAuth flow.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has NOT yet connected their Google account.
+
+---
+
+**Step 1**
+
+1\. In any channel, run /meet connect.\
+2\. Click the link in the ephemeral response to start the Google OAuth flow.\
+3\. Log in to Google and approve the requested scopes when prompted.
+
+**Test Data**
+
+Slash command: /meet connect
+
+**Expected**
+
+1\. An ephemeral message is shown with a link to start the OAuth flow.\
+2\. The Google OAuth consent screen opens in the browser.\
+3\. After approval, the user is redirected back and a confirmation message indicates the Google account is now connected.

--- a/data/test-cases/plugins/google-meet/MM-T6075.md
+++ b/data/test-cases/plugins/google-meet/MM-T6075.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Disconnect Google account via /meet disconnect'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6075
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6075: Disconnect Google account via /meet disconnect
+
+**Objective**
+
+Verify a user can disconnect their Google account from Mattermost using the /meet disconnect slash command.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. In any channel, run /meet disconnect.\
+2\. Run /meet start to confirm the disconnection.
+
+**Test Data**
+
+Slash command: /meet disconnect
+
+**Expected**
+
+1\. A confirmation message indicates the Google account has been disconnected.\
+2\. /meet start now prompts the user to connect their Google account again.

--- a/data/test-cases/plugins/google-meet/MM-T6076.md
+++ b/data/test-cases/plugins/google-meet/MM-T6076.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet start while disconnected returns a connect prompt'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6076
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6076: /meet start while disconnected returns a connect prompt
+
+**Objective**
+
+Verify that attempting to start a meeting while the user has no Google connection prompts them to connect.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User is NOT connected to Google.
+
+---
+
+**Step 1**
+
+1\. Ensure the user has no active Google connection (run /meet disconnect if needed).\
+2\. In a channel, run /meet start.
+
+**Test Data**
+
+Slash command: /meet start
+
+**Expected**
+
+1\. The user is disconnected.\
+2\. An ephemeral message is shown asking the user to connect their Google account, including a connect link.

--- a/data/test-cases/plugins/google-meet/MM-T6077.md
+++ b/data/test-cases/plugins/google-meet/MM-T6077.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'User prompted to reconnect after EnableConferenceArtifactPosts is enabled post-connect'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6077
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6077: User prompted to reconnect after EnableConferenceArtifactPosts is enabled post-connect
+
+**Objective**
+
+Verify that when EnableConferenceArtifactPosts is enabled after a user has already connected, the user is prompted to reconnect so the additional meetings.space.readonly scope can be granted.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User connected their Google account while EnableConferenceArtifactPosts was set to false. A System Admin has now toggled EnableConferenceArtifactPosts from false to true.
+
+---
+
+**Step 1**
+
+1\. As System Admin, ensure EnableConferenceArtifactPosts was previously false and is now toggled to true.\
+2\. As the previously connected user, run a /meet subscription command (e.g. /meet subscription list) or trigger a feature that requires the readonly scope.
+
+**Test Data**
+
+Setting: EnableConferenceArtifactPosts toggled false -> true
+
+**Expected**
+
+1\. Setting is saved.\
+2\. An ephemeral message is shown asking the user to reconnect their Google account because additional scopes are required, with a reconnect link.

--- a/data/test-cases/plugins/google-meet/MM-T6078.md
+++ b/data/test-cases/plugins/google-meet/MM-T6078.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet help lists supported subcommands'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6078
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6078: /meet help lists supported subcommands
+
+**Objective**
+
+Verify the /meet help command lists all supported subcommands.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost.
+
+---
+
+**Step 1**
+
+1\. In any channel, run /meet help.
+
+**Test Data**
+
+Slash command: /meet help
+
+**Expected**
+
+An ephemeral message lists the supported subcommands (connect, disconnect, start, subscription, help) with brief descriptions.

--- a/data/test-cases/plugins/google-meet/MM-T6079.md
+++ b/data/test-cases/plugins/google-meet/MM-T6079.md
@@ -1,0 +1,59 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Unknown /meet subcommand returns help or error'
+status: Active
+priority: Low
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P4 - Low-Impact (Edge or unsuitable to repeat?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6079
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6079: Unknown /meet subcommand returns help or error
+
+**Objective**
+
+Verify that an unknown /meet subcommand returns an error or help message rather than failing silently.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost.
+
+---
+
+**Step 1**
+
+1\. In any channel, run /meet foo.
+
+**Test Data**
+
+Slash command: /meet foo
+
+**Expected**
+
+An ephemeral message informs the user that the subcommand is unknown and/or displays the help text.

--- a/data/test-cases/plugins/google-meet/MM-T6080.md
+++ b/data/test-cases/plugins/google-meet/MM-T6080.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet start with no topic posts a meeting link in the current channel'
+status: Active
+priority: High
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6080
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6080: /meet start with no topic posts a meeting link in the current channel
+
+**Objective**
+
+Verify that /meet start with no topic creates a Google Meet meeting and posts the join link in the current channel.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /meet start.\
+2\. Observe the resulting post in the channel.
+
+**Test Data**
+
+Slash command: /meet start
+
+**Expected**
+
+1\. A new post from the Google Meet bot appears in the channel.\
+2\. The post contains a Google Meet URL and a join action.

--- a/data/test-cases/plugins/google-meet/MM-T6081.md
+++ b/data/test-cases/plugins/google-meet/MM-T6081.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet start <topic> includes the topic on the resulting post'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6081
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6081: /meet start <topic> includes the topic on the resulting post
+
+**Objective**
+
+Verify that the optional topic argument to /meet start is included on the created meeting post.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /meet start Sprint planning.\
+2\. Observe the resulting post in the channel.
+
+**Test Data**
+
+Slash command: /meet start Sprint planning
+
+**Expected**
+
+1\. A new post from the Google Meet bot appears with the topic 'Sprint planning' visible in the post.\
+2\. The post contains a Google Meet URL and a join action.

--- a/data/test-cases/plugins/google-meet/MM-T6082.md
+++ b/data/test-cases/plugins/google-meet/MM-T6082.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Channel header Google Meet button starts a meeting'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6082
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6082: Channel header Google Meet button starts a meeting
+
+**Objective**
+
+Verify that clicking the Google Meet channel header button creates a meeting equivalent to running /meet start.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. Open a channel that displays the Google Meet channel header button.\
+2\. Click the Google Meet channel header button.\
+3\. Observe the resulting post in the channel.
+
+**Test Data**
+
+UI: Google Meet channel header button
+
+**Expected**
+
+1\. The channel header button is visible.\
+2\. A meeting is created.\
+3\. A new post from the Google Meet bot appears in the channel containing a Google Meet URL and a join action, equivalent to /meet start.

--- a/data/test-cases/plugins/google-meet/MM-T6083.md
+++ b/data/test-cases/plugins/google-meet/MM-T6083.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Created meeting post contains a working Google Meet URL'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6083
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6083: Created meeting post contains a working Google Meet URL
+
+**Objective**
+
+Verify the URL in a /meet start post opens a valid Google Meet meeting room.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. Run /meet start in a channel.\
+2\. Click the Google Meet URL in the resulting post.
+
+**Test Data**
+
+Slash command: /meet start
+
+**Expected**
+
+1\. The post is created with a meet.google.com URL.\
+2\. The URL opens a Google Meet meeting room in the browser.

--- a/data/test-cases/plugins/google-meet/MM-T6084.md
+++ b/data/test-cases/plugins/google-meet/MM-T6084.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Created meeting post contains a visible Join action button'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6084
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6084: Created meeting post contains a visible Join action button
+
+**Objective**
+
+Verify the created meeting post renders a clear Join action in the Mattermost UI.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.
+
+---
+
+**Step 1**
+
+1\. Run /meet start in a channel.\
+2\. Inspect the created post in the channel.
+
+**Test Data**
+
+Slash command: /meet start
+
+**Expected**
+
+1\. The post is created.\
+2\. A visible Join action button or link is present on the post.

--- a/data/test-cases/plugins/google-meet/MM-T6085.md
+++ b/data/test-cases/plugins/google-meet/MM-T6085.md
@@ -1,0 +1,61 @@
+---
+# (Required) Ensure all values are filled up
+name: 'RestrictMeetingCreation blocks /meet start in a public channel'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6085
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6085: RestrictMeetingCreation blocks /meet start in a public channel
+
+**Objective**
+
+Verify that with RestrictMeetingCreation enabled, /meet start in a public channel is blocked with a clear message.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow. System Admin has set RestrictMeetingCreation to true. The current channel is a public channel.
+
+---
+
+**Step 1**
+
+1\. Open a public channel.\
+2\. Run /meet start.
+
+**Test Data**
+
+Setting: RestrictMeetingCreation=true; Channel type: public
+
+**Expected**
+
+1\. The current channel is public.\
+2\. An ephemeral message informs the user that meeting creation is restricted in public channels. No meeting post is created.

--- a/data/test-cases/plugins/google-meet/MM-T6086.md
+++ b/data/test-cases/plugins/google-meet/MM-T6086.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'RestrictMeetingCreation still allows /meet start in private channel, DM, and GM'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6086
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6086: RestrictMeetingCreation still allows /meet start in private channel, DM, and GM
+
+**Objective**
+
+Verify that with RestrictMeetingCreation enabled, /meet start still succeeds in private channels, direct messages, and group messages.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow. System Admin has set RestrictMeetingCreation to true.
+
+---
+
+**Step 1**
+
+1\. In a private channel, run /meet start.\
+2\. In a direct message (DM), run /meet start.\
+3\. In a group message (GM), run /meet start.
+
+**Test Data**
+
+Setting: RestrictMeetingCreation=true; Surfaces: private channel, DM, GM
+
+**Expected**
+
+1\. A meeting post is created in the private channel.\
+2\. A meeting post is created in the DM.\
+3\. A meeting post is created in the GM.

--- a/data/test-cases/plugins/google-meet/MM-T6087.md
+++ b/data/test-cases/plugins/google-meet/MM-T6087.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Channel header Google Meet button is hidden for non-admin users until plugin is fully configured'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6087
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6087: Channel header Google Meet button is hidden for non-admin users until plugin is fully configured
+
+**Objective**
+
+Verify the channel header Google Meet button is not shown to non-admin users while the plugin is not fully configured.
+
+**Precondition**
+
+Plugin is installed but NOT fully configured (e.g. Google Client ID/Secret is empty or SiteURL is missing). A non-admin user is logged in.
+
+---
+
+**Step 1**
+
+1\. As a non-admin user, open any channel and inspect the channel header.\
+2\. As a System Admin, complete the plugin configuration.\
+3\. As the non-admin user, reload Mattermost and re-open the channel header.
+
+**Test Data**
+
+Plugin configured state: incomplete then complete
+
+**Expected**
+
+1\. The Google Meet channel header button is NOT visible to the non-admin user.\
+2\. Plugin is now fully configured.\
+3\. The Google Meet channel header button is now visible to the non-admin user.

--- a/data/test-cases/plugins/google-meet/MM-T6088.md
+++ b/data/test-cases/plugins/google-meet/MM-T6088.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet subscription add succeeds and confirmation includes the description'
+status: Active
+priority: High
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6088
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6088: /meet subscription add succeeds and confirmation includes the description
+
+**Objective**
+
+Verify that /meet subscription add with a meeting code and description registers the subscription and the immediate confirmation message includes the description text.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /meet subscription add abc-mnop-xyz Weekly engineering sync.\
+2\. Run /meet subscription list to verify the subscription is registered.
+
+**Test Data**
+
+Command: /meet subscription add abc-mnop-xyz Weekly engineering sync
+
+**Expected**
+
+1\. A confirmation message is shown for the new subscription, and the description 'Weekly engineering sync' is visible in the confirmation.\
+2\. The new subscription appears in the listed subscriptions for the channel.

--- a/data/test-cases/plugins/google-meet/MM-T6089.md
+++ b/data/test-cases/plugins/google-meet/MM-T6089.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet subscription add accepts a full meet.google.com URL'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6089
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6089: /meet subscription add accepts a full meet.google.com URL
+
+**Objective**
+
+Verify that /meet subscription add accepts a full meet.google.com URL equivalently to a bare meeting code.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription.
+
+---
+
+**Step 1**
+
+1\. In a channel, run /meet subscription add https://meet.google.com/abc-mnop-xyz URL form.\
+2\. Run /meet subscription list.
+
+**Test Data**
+
+Command: /meet subscription add https://meet.google.com/abc-mnop-xyz URL form
+
+**Expected**
+
+1\. A confirmation message is shown for the new subscription.\
+2\. The subscription appears in the channel's subscription list with the same meeting space as if the bare code had been used.

--- a/data/test-cases/plugins/google-meet/MM-T6090.md
+++ b/data/test-cases/plugins/google-meet/MM-T6090.md
@@ -1,0 +1,60 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet subscription list shows current channel subscriptions'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6090
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6090: /meet subscription list shows current channel subscriptions
+
+**Objective**
+
+Verify /meet subscription list returns the current subscriptions for the calling user in this channel.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. At least one subscription has been added in the current channel by the calling user.
+
+---
+
+**Step 1**
+
+1\. In the channel, run /meet subscription list.
+
+**Test Data**
+
+Command: /meet subscription list
+
+**Expected**
+
+A response is returned listing the existing subscriptions for this channel, including meeting code/URL and description for each.

--- a/data/test-cases/plugins/google-meet/MM-T6091.md
+++ b/data/test-cases/plugins/google-meet/MM-T6091.md
@@ -1,0 +1,62 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet subscription remove removes an existing subscription'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6091
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6091: /meet subscription remove removes an existing subscription
+
+**Objective**
+
+Verify /meet subscription remove deletes an existing subscription.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. A subscription for meeting code abc-mnop-xyz exists in the current channel.
+
+---
+
+**Step 1**
+
+1\. In the channel, run /meet subscription remove abc-mnop-xyz.\
+2\. Run /meet subscription list.
+
+**Test Data**
+
+Command: /meet subscription remove abc-mnop-xyz
+
+**Expected**
+
+1\. A confirmation message is shown indicating the subscription was removed.\
+2\. The removed subscription no longer appears in the channel's subscription list.

--- a/data/test-cases/plugins/google-meet/MM-T6092.md
+++ b/data/test-cases/plugins/google-meet/MM-T6092.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet subscription commands return disabled message when EnableConferenceArtifactPosts=false'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6092
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6092: /meet subscription commands return disabled message when EnableConferenceArtifactPosts=false
+
+**Objective**
+
+Verify all /meet subscription subcommands return a clear admin-facing message when EnableConferenceArtifactPosts is disabled.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow. System Admin has set EnableConferenceArtifactPosts to false.
+
+---
+
+**Step 1**
+
+1\. Run /meet subscription add abc-mnop-xyz Test.\
+2\. Run /meet subscription list.\
+3\. Run /meet subscription remove abc-mnop-xyz.
+
+**Test Data**
+
+Setting: EnableConferenceArtifactPosts=false
+
+**Expected**
+
+1\. An ephemeral message indicates channel subscriptions are disabled and points the user to the setting.\
+2\. An ephemeral message indicates channel subscriptions are disabled and points the user to the setting.\
+3\. An ephemeral message indicates channel subscriptions are disabled and points the user to the setting.

--- a/data/test-cases/plugins/google-meet/MM-T6093.md
+++ b/data/test-cases/plugins/google-meet/MM-T6093.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Subscribed channel receives a conference started post when a meeting starts in the Meet space'
+status: Active
+priority: High
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6093
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6093: Subscribed channel receives a conference started post when a meeting starts in the Meet space
+
+**Objective**
+
+Verify a 'conference started' post is created in the subscribed channel when a meeting begins in the subscribed Meet space.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. A subscription exists in the current channel for Meet space abc-mnop-xyz.
+
+---
+
+**Step 1**
+
+1\. Start a meeting in Google Meet using the subscribed space (e.g. https://meet.google.com/abc-mnop-xyz).\
+2\. Wait at least one poll interval (default 60 seconds).\
+3\. Observe the subscribed Mattermost channel.
+
+**Test Data**
+
+Meet space: abc-mnop-xyz; Poll interval: 60s default
+
+**Expected**
+
+1\. The Google Meet meeting starts.\
+2\. After the poll interval, a 'conference started' post from the Google Meet bot appears in the subscribed channel.\
+3\. The post identifies the meeting space and provides a join link.

--- a/data/test-cases/plugins/google-meet/MM-T6094.md
+++ b/data/test-cases/plugins/google-meet/MM-T6094.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Recording artifact is posted as a thread reply after the meeting ends'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6094
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6094: Recording artifact is posted as a thread reply after the meeting ends
+
+**Objective**
+
+Verify the recording link is posted as a reply in the meeting's Mattermost thread after Google finishes processing it.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. The Google Meet space has recording, transcription, and smart notes enabled, and the Workspace tier supports these features. A subscription exists for Meet space abc-mnop-xyz in the current channel, and a meeting in that space with recording enabled has just ended.
+
+---
+
+**Step 1**
+
+1\. Confirm the meeting has ended and Google has produced a recording.\
+2\. Wait for the plugin's polling interval and for Google to finish processing (may take several minutes).\
+3\. Open the thread of the 'conference started' post in the subscribed channel.
+
+**Test Data**
+
+Meet space: abc-mnop-xyz with recording enabled
+
+**Expected**
+
+1\. The meeting recording is available in Google Drive.\
+2\. The polling interval has elapsed and Google has finished processing.\
+3\. A reply post in the meeting thread contains a link to the recording in Google Drive.

--- a/data/test-cases/plugins/google-meet/MM-T6095.md
+++ b/data/test-cases/plugins/google-meet/MM-T6095.md
@@ -1,0 +1,66 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Transcript artifact is posted as a thread reply with a WebVTT attachment'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6095
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6095: Transcript artifact is posted as a thread reply with a WebVTT attachment
+
+**Objective**
+
+Verify the transcript is posted as a reply in the meeting's thread and a WebVTT file is attached to that reply.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. The Google Meet space has recording, transcription, and smart notes enabled, and the Workspace tier supports these features. A subscription exists for Meet space abc-mnop-xyz in the current channel, and a meeting in that space with transcription enabled has just ended.
+
+---
+
+**Step 1**
+
+1\. Confirm the meeting has ended and Google has produced a transcript.\
+2\. Wait for the plugin's polling interval and for Google to finish processing.\
+3\. Open the thread of the 'conference started' post in the subscribed channel.\
+4\. Inspect the transcript reply for an attached WebVTT file.
+
+**Test Data**
+
+Meet space: abc-mnop-xyz with transcription enabled
+
+**Expected**
+
+1\. The meeting transcript is available in Google Docs.\
+2\. Processing is complete.\
+3\. A reply post in the meeting thread contains a link to the transcript in Google Docs.\
+4\. A WebVTT (.vtt) file is attached to the same reply.

--- a/data/test-cases/plugins/google-meet/MM-T6096.md
+++ b/data/test-cases/plugins/google-meet/MM-T6096.md
@@ -1,0 +1,64 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Smart notes artifact is posted as a thread reply'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6096
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6096: Smart notes artifact is posted as a thread reply
+
+**Objective**
+
+Verify the smart notes link is posted as a reply in the meeting's thread after Google finishes processing it.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. The Google Meet space has recording, transcription, and smart notes enabled, and the Workspace tier supports these features. A subscription exists for Meet space abc-mnop-xyz in the current channel, and a meeting in that space with smart notes enabled has just ended.
+
+---
+
+**Step 1**
+
+1\. Confirm the meeting has ended and Google has produced smart notes.\
+2\. Wait for the plugin's polling interval and for Google to finish processing.\
+3\. Open the thread of the 'conference started' post in the subscribed channel.
+
+**Test Data**
+
+Meet space: abc-mnop-xyz with smart notes enabled
+
+**Expected**
+
+1\. Smart notes are available in Google Docs.\
+2\. Processing is complete.\
+3\. A reply post in the meeting thread contains a link to the smart notes in Google Docs.

--- a/data/test-cases/plugins/google-meet/MM-T6097.md
+++ b/data/test-cases/plugins/google-meet/MM-T6097.md
@@ -1,0 +1,66 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Ad-hoc /meet start meeting artifacts are posted as replies to the original /meet start post'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6097
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6097: Ad-hoc /meet start meeting artifacts are posted as replies to the original /meet start post
+
+**Objective**
+
+Verify that recording, transcript, and smart notes for an ad-hoc /meet start meeting are posted as replies to the original /meet start post.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow.\
+EnableConferenceArtifactPosts is set to true. Tester has access to at least one Google Meet space (a meeting code such as abc-mnop-xyz) usable for subscription. The Google Meet space has recording, transcription, and smart notes enabled, and the Workspace tier supports these features. The user has just run /meet start (no subscription required) and the resulting meeting (with recording / transcription / smart notes enabled in the space) has ended.
+
+---
+
+**Step 1**
+
+1\. Run /meet start in a channel and complete a short meeting with recording, transcription, and smart notes enabled.\
+2\. End the meeting.\
+3\. Wait for the plugin's polling interval and for Google to finish processing.\
+4\. Open the thread of the original /meet start post.
+
+**Test Data**
+
+Command: /meet start; Meet space artifacts enabled
+
+**Expected**
+
+1\. Meeting starts and the post appears in the channel.\
+2\. Meeting ends; artifacts begin processing in Google.\
+3\. Processing is complete.\
+4\. Replies to the original /meet start post contain links to the recording, transcript (with WebVTT attached), and smart notes.

--- a/data/test-cases/plugins/google-meet/MM-T6098.md
+++ b/data/test-cases/plugins/google-meet/MM-T6098.md
@@ -1,0 +1,67 @@
+---
+# (Required) Ensure all values are filled up
+name: 'System Admin configures Google Meet plugin and enables it'
+status: Active
+priority: High
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P1 - Smoke Tests (App testable?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6098
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6098: System Admin configures Google Meet plugin and enables it
+
+**Objective**
+
+Verify the Google Meet plugin can be configured and enabled from the System Console without errors.
+
+**Precondition**
+
+User is a System Admin. Mattermost SiteURL is set. Google Cloud has Google Meet REST API enabled and OAuth 2.0 Web application client credentials available.
+
+---
+
+**Step 1**
+
+1\. Navigate to System Console > Plugins > Google Meet.\
+2\. Enter Google OAuth Client ID and Client Secret.\
+3\. Generate an Encryption Key.\
+4\. Save the configuration and ensure the plugin is enabled.\
+5\. Return to a channel and run /meet help.
+
+**Test Data**
+
+Settings: GoogleClientID, GoogleClientSecret, Encryption Key
+
+**Expected**
+
+1\. The Google Meet plugin settings page loads.\
+2\. The values are accepted.\
+3\. A new Encryption Key is generated.\
+4\. The plugin is saved and enabled without errors.\
+5\. /meet slash commands are available in channels.

--- a/data/test-cases/plugins/google-meet/MM-T6099.md
+++ b/data/test-cases/plugins/google-meet/MM-T6099.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Plugin reports not configured when SiteURL is missing'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6099
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6099: Plugin reports not configured when SiteURL is missing
+
+**Objective**
+
+Verify the plugin reports a not-configured state when SiteURL is missing, since SiteURL is required to build the OAuth callback URL.
+
+**Precondition**
+
+User is a System Admin. The Google Meet plugin is installed. Mattermost SiteURL is empty/unset.
+
+---
+
+**Step 1**
+
+1\. Ensure SiteURL is empty in System Console > General > Configuration.\
+2\. Navigate to System Console > Plugins > Google Meet.\
+3\. As a regular user, run /meet connect.
+
+**Test Data**
+
+Config: SiteURL empty
+
+**Expected**
+
+1\. SiteURL is empty.\
+2\. The plugin settings page indicates the plugin is not fully configured (e.g. the redirect URI cannot be shown / a warning is displayed).\
+3\. /meet connect either fails with a clear not-configured message or surfaces an admin-facing error rather than completing OAuth.

--- a/data/test-cases/plugins/google-meet/MM-T6100.md
+++ b/data/test-cases/plugins/google-meet/MM-T6100.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Rotating Encryption Key invalidates existing user connections'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P3 - Deep Functions (Do extensive scenarios work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6100
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6100: Rotating Encryption Key invalidates existing user connections
+
+**Objective**
+
+Verify that regenerating the Encryption Key invalidates existing stored Google connections and the user is prompted to reconnect.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key). Mattermost SiteURL is set. User is logged into Mattermost. User has previously run /meet connect and successfully completed the Google OAuth flow. At least one user has an existing Google connection.
+
+---
+
+**Step 1**
+
+1\. As a connected user, run /meet start to confirm the connection works.\
+2\. As System Admin, navigate to System Console > Plugins > Google Meet and regenerate the Encryption Key, then Save.\
+3\. As the previously connected user, run /meet start again.
+
+**Test Data**
+
+Action: Regenerate Encryption Key
+
+**Expected**
+
+1\. /meet start works and a meeting post is created.\
+2\. The Encryption Key is regenerated and the plugin is saved.\
+3\. /meet start now prompts the user to reconnect their Google account.

--- a/data/test-cases/plugins/google-meet/MM-T6101.md
+++ b/data/test-cases/plugins/google-meet/MM-T6101.md
@@ -1,0 +1,63 @@
+---
+# (Required) Ensure all values are filled up
+name: 'Disabling the plugin removes slash commands and channel header button'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6101
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6101: Disabling the plugin removes slash commands and channel header button
+
+**Objective**
+
+Verify that disabling the plugin removes its slash commands and the channel header button from Mattermost.
+
+**Precondition**
+
+User is a System Admin. The Google Meet plugin is enabled.
+
+---
+
+**Step 1**
+
+1\. Navigate to System Console > Plugins > Plugin Management.\
+2\. Disable the Google Meet plugin.\
+3\. Return to a channel and attempt to use /meet commands and inspect the channel header.
+
+**Test Data**
+
+Plugin state: disabled
+
+**Expected**
+
+1\. The plugin list loads.\
+2\. The plugin is disabled successfully.\
+3\. /meet slash commands are no longer available and the Google Meet channel header button is not visible.

--- a/data/test-cases/plugins/google-meet/MM-T6102.md
+++ b/data/test-cases/plugins/google-meet/MM-T6102.md
@@ -1,0 +1,68 @@
+---
+# (Required) Ensure all values are filled up
+name: '/meet start run in a thread posts the meeting in the thread, not the central channel'
+status: Active
+priority: Normal
+folder: Google Meet
+authors: '@ogi-m'
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ''
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: MM-T6102
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+<!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
+
+## MM-T6102: /meet start run in a thread posts the meeting in the thread, not the central channel
+
+**Objective**
+
+Verify that running /meet start as a reply inside an existing thread posts the resulting meeting message inside the thread, not in the central channel. Regression coverage for the bug fixed in mattermost-plugin-google-meet PR #14.
+
+**Precondition**
+
+Plugin is installed and configured with valid Google OAuth credentials (Client ID, Client Secret, generated Encryption Key).\
+Mattermost SiteURL is set.\
+User is logged into Mattermost and has previously run /meet connect and successfully completed the Google OAuth flow.\
+An existing post with at least one reply exists in the current channel so a thread can be opened.
+
+---
+
+**Step 1**
+
+1\. In the channel, open the thread of an existing post (in the RHS or via 'Reply').\
+2\. In the thread's reply input box, type /meet start and send.\
+3\. Observe the thread (RHS).\
+4\. Observe the central channel timeline.
+
+**Test Data**
+
+Slash command: /meet start (executed from inside a thread reply input)
+
+**Expected**
+
+1\. The thread opens in the RHS with focus on the reply input.\
+2\. /meet start is accepted.\
+3\. The Google Meet bot post containing the meeting URL and join action appears as a reply inside the thread.\
+4\. No new top-level post for the meeting appears in the central channel; the meeting message exists only inside the thread.


### PR DESCRIPTION
#### Summary

Adds 29 new manual test cases for the Google Meet plugin (https://github.com/mattermost/mattermost-plugin-google-meet) under data/test-cases/plugins/google-meet/, covering happy-path coverage of the plugin's primary user-facing features plus one regression test for a recently fixed bug.
Test cases were authored against the current master of the plugin and imported into Zephyr Scale as MM-T6074 through MM-T6102. The plugin had no prior coverage in this repo, so this is a greenfield batch.

#### Coverage

29 test cases (MM-T6074..MM-T6102) across 7 functional areas:
- Authentication (4): /meet connect, /meet disconnect, disconnected-state guard, reconnect prompt after admin enables EnableConferenceArtifactPosts post-connect.
- Slash Commands (2): /meet help, unknown subcommand.
- Ad-hoc meeting creation (5): /meet start (no topic), /meet start <topic>, channel header button, working Meet URL on post, visible Join action.
- Restrictions (3): RestrictMeetingCreation blocks public channels, allows private/DM/GM, channel header button hidden for non-admins until plugin fully configured.
- Channel subscriptions (5): add (with description in confirmation), add via full URL, list, remove, disabled-by-admin message when EnableConferenceArtifactPosts=false.
- Conference notifications and artifacts (5): conference-started post, recording reply, transcript reply with WebVTT attachment, smart notes reply, artifact replies for ad-hoc /meet start meetings.
- Admin (4): configure plugin, not-configured state when SiteURL missing, encryption key rotation invalidates connections, disabling plugin removes commands and button.
- Recent bug (1): /meet start run from inside a thread posts the meeting in the thread (not in the central channel) - covers the bug fixed in mattermost-plugin-google-meet#14 (https://github.com/mattermost/mattermost-plugin-google-meet/pull/14).
Priority distribution: 5 P1 (smoke), 15 P2 (core, including the regression), 8 P3 (deep), 1 P4 (edge).

#### Validation:

- deno task validate: PASSED (all 29 files validated; new folder plugins/google-meet registered as Google Meet).
- deno fmt --check: PASSED across the 29 new files.